### PR TITLE
> fix debug info no newline if kernel version less than 5.9

### DIFF
--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -16,6 +16,29 @@ else
 $(error MESH_MODE $(MESH_MODE) isn't supported)
 endif
 
+# see https://stackoverflow.com/questions/15063298/how-to-check-kernel-version-in-makefile
+KVER = $(shell uname -r)
+KMAJ = $(shell echo $(KVER) | \
+sed -e 's/^\([0-9][0-9]*\)\.[0-9][0-9]*\.[0-9][0-9]*.*/\1/')
+KMIN = $(shell echo $(KVER) | \
+sed -e 's/^[0-9][0-9]*\.\([0-9][0-9]*\)\.[0-9][0-9]*.*/\1/')
+KREV = $(shell echo $(KVER) | \
+sed -e 's/^[0-9][0-9]*\.[0-9][0-9]*\.\([0-9][0-9]*\).*/\1/')
+
+kver_ge = $(shell \
+echo test | awk '{if($(KMAJ) < $(1)) {print 0} else { \
+if($(KMAJ) > $(1)) {print 1} else { \
+if($(KMIN) < $(2)) {print 0} else { \
+if($(KMIN) > $(2)) {print 1} else { \
+if($(KREV) < $(3)) {print 0} else { print 1 } \
+}}}}}' \
+)
+
+# See https://nakryiko.com/posts/bpf-tips-printk/, kernel will auto print newline if version gather than 5.9.0
+ifneq ($(call kver_ge,5,8,999),1)
+MACROS:= $(MACROS) -DPRINTNL # kernel version less 
+endif
+
 ifeq ($(DEBUG),1)
     MACROS:= $(MACROS) -DDEBUG
 endif

--- a/bpf/headers/helpers.h
+++ b/bpf/headers/helpers.h
@@ -56,10 +56,16 @@ static long (*bpf_msg_redirect_hash)(struct sk_msg_md *md, struct bpf_map *map,
                                      void *key, __u64 flags) = (void *)
     BPF_FUNC_msg_redirect_hash;
 
+#ifdef PRINTNL
+#define PRINT_SUFFIX "\n"
+#else
+#define PRINT_SUFFIX ""
+#endif
+
 #ifndef printk
 #define printk(fmt, ...)                                                       \
     ({                                                                         \
-        char ____fmt[] = fmt;                                                  \
+        char ____fmt[] = fmt PRINT_SUFFIX;                                     \
         bpf_trace_printk(____fmt, sizeof(____fmt), ##__VA_ARGS__);             \
     })
 #endif
@@ -70,7 +76,11 @@ static long (*bpf_msg_redirect_hash)(struct sk_msg_md *md, struct bpf_map *map,
 #else
 // only print traceing in debug mode
 #ifndef debugf
-#define debugf printk
+#define debugf(fmt, ...)                                                       \
+    ({                                                                         \
+        char ____fmt[] = "[debug] " fmt PRINT_SUFFIX;                          \
+        bpf_trace_printk(____fmt, sizeof(____fmt), ##__VA_ARGS__);             \
+    })
 #endif
 
 #endif


### PR DESCRIPTION
Fix https://github.com/merbridge/merbridge/issues/41