### PR TITLE
Correct the key size of `cookie_original_dst`

### DIFF
--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -67,7 +67,7 @@ compile-clean:
 
 # Map
 load-map-cookie_original_dst:
-	[ -f $(PROG_MOUNT_PATH)/cookie_original_dst ] || sudo bpftool map create $(PROG_MOUNT_PATH)/cookie_original_dst type lru_hash key 4 value 12 entries 65535 name cookie_original_dst
+	[ -f $(PROG_MOUNT_PATH)/cookie_original_dst ] || sudo bpftool map create $(PROG_MOUNT_PATH)/cookie_original_dst type lru_hash key 8 value 12 entries 65535 name cookie_original_dst
 
 load-map-local_pod_ips:
 	[ -f $(PROG_MOUNT_PATH)/local_pod_ips ] || sudo bpftool map create $(PROG_MOUNT_PATH)/local_pod_ips type hash key 4 value 4 entries 1024 name local_pod_ips

--- a/bpf/headers/maps.h
+++ b/bpf/headers/maps.h
@@ -18,7 +18,7 @@ limitations under the License.
 
 struct bpf_map __section("maps") cookie_original_dst = {
     .type = BPF_MAP_TYPE_LRU_HASH,
-    .key_size = sizeof(__u32),
+    .key_size = sizeof(__u64),
     .value_size = sizeof(struct origin_info),
     .max_entries = 65535,
     .map_flags = 0,


### PR DESCRIPTION
The return type of `bpf_get_socket_cookie` is u64

       u64 bpf_get_socket_cookie(struct bpf_sock_addr *ctx)

              Description
                     Equivalent to bpf_get_socket_cookie() helper that
                     accepts skb, but gets socket from struct
                     bpf_sock_addr context.

              Return A 8-byte long non-decreasing number.