### PR TITLE
Redirect msg to the ingress path of peer socket

### DIFF
--- a/bpf/mb_get_sockopts.c
+++ b/bpf/mb_get_sockopts.c
@@ -38,7 +38,7 @@ __section("cgroup/getsockopt") int mb_get_sockopt(struct bpf_sockopt *ctx)
             .dip = ctx->sk->src_ip4,
             .dport = bpf_htons(ctx->sk->src_port),
             .sip = ctx->sk->dst_ip4,
-            .sport = bpf_htons(ctx->sk->dst_port),
+            .sport = ctx->sk->dst_port,
         };
         struct origin_info *origin =
             bpf_map_lookup_elem(&pair_original_dst, &p);

--- a/bpf/mb_redir.c
+++ b/bpf/mb_redir.c
@@ -21,12 +21,12 @@ limitations under the License.
 __section("sk_msg") int mb_msg_redir(struct sk_msg_md *msg)
 {
     struct pair p = {
-        .sip = msg->local_ip4,
-        .sport = msg->local_port,
-        .dip = msg->remote_ip4,
-        .dport = msg->remote_port >> 16,
+        .dip = msg->local_ip4,
+        .dport = bpf_htons(msg->local_port),
+        .sip = msg->remote_ip4,
+        .sport = msg->remote_port >> 16,
     };
-    long ret = bpf_msg_redirect_hash(msg, &sock_pair_map, &p, 0);
+    long ret = bpf_msg_redirect_hash(msg, &sock_pair_map, &p, BPF_F_INGRESS);
     if (ret)
         debugf("redirect %d bytes with eBPF successfully", msg->size);
     return 1;

--- a/bpf/mb_sockops.c
+++ b/bpf/mb_sockops.c
@@ -25,7 +25,7 @@ static inline int sockops_ipv4(struct bpf_sock_ops *skops)
 
     struct pair p = {
         .sip = skops->local_ip4,
-        .sport = skops->local_port,
+        .sport = bpf_htons(skops->local_port),
         .dip = skops->remote_ip4,
         .dport = skops->remote_port >> 16,
     };
@@ -56,7 +56,7 @@ static inline int sockops_ipv4(struct bpf_sock_ops *skops)
         }
         // get_sockopts can read pid and cookie,
         // we should write a new map named pair_original_dst
-        bpf_map_update_elem(&pair_original_dst, &p, &dd, BPF_NOEXIST);
+        bpf_map_update_elem(&pair_original_dst, &p, &dd, BPF_ANY);
         bpf_sock_hash_update(skops, &sock_pair_map, &p, BPF_NOEXIST);
     } else {
         if (skops->local_port == OUT_REDIRECT_PORT ||


### PR DESCRIPTION
Skip the transportation between a pair of sockets to improve performance