### PR TITLE
Add support for ipv6

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -20,7 +20,7 @@ jobs:
       uses: golangci/golangci-lint-action@v3
       with:
         # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-        version: v1.29
+        version: v1.45
     - name: install clang-format
       run: sudo apt update && sudo apt install -y clang-format
     - name: Code check

--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -19,6 +19,21 @@ else
 $(error MESH_MODE $(MESH_MODE) isn't supported)
 endif
 
+ENABLE_IPV4 ?= true
+ENABLE_IPV6 ?= false
+
+ifeq ($(ENABLE_IPV4),true)
+	MACROS:= $(MACROS) -DENABLE_IPV4=1
+else
+	MACROS:= $(MACROS) -DENABLE_IPV4=0
+endif
+
+ifeq ($(ENABLE_IPV6),true)
+	MACROS:= $(MACROS) -DENABLE_IPV6=1
+else
+	MACROS:= $(MACROS) -DENABLE_IPV6=0
+endif
+
 # see https://stackoverflow.com/questions/15063298/how-to-check-kernel-version-in-makefile
 KVER = $(shell uname -r)
 KMAJ = $(shell echo $(KVER) | \
@@ -74,22 +89,22 @@ compile-clean:
 
 # Map
 load-map-cookie_original_dst:
-	[ -f $(PROG_MOUNT_PATH)/cookie_original_dst ] || sudo bpftool map create $(PROG_MOUNT_PATH)/cookie_original_dst type lru_hash key 8 value 12 entries 65535 name cookie_original_dst
+	[ -f $(PROG_MOUNT_PATH)/cookie_original_dst ] || sudo bpftool map create $(PROG_MOUNT_PATH)/cookie_original_dst type lru_hash key 8 value 24 entries 65535 name cookie_original_dst
 
 load-map-local_pod_ips:
-	[ -f $(TC_PINNING_PATH)/local_pod_ips ] || sudo bpftool map create $(TC_PINNING_PATH)/local_pod_ips type hash key 4 value 244 entries 1024 name local_pod_ips
+	[ -f $(TC_PINNING_PATH)/local_pod_ips ] || sudo bpftool map create $(TC_PINNING_PATH)/local_pod_ips type hash key 16 value 244 entries 1024 name local_pod_ips
 
 load-map-process_ip:
 	[ -f $(PROG_MOUNT_PATH)/process_ip ] || sudo bpftool map create $(PROG_MOUNT_PATH)/process_ip type lru_hash key 4 value 4 entries 1024 name process_ip
 
 load-map-mark_pod_ips_map:
-	[ -f $(PROG_MOUNT_PATH)/mark_pod_ips_map ] || sudo bpftool map create $(PROG_MOUNT_PATH)/mark_pod_ips_map type hash key 4 value 4 entries 65535 name mark_pod_ips_map
+	[ -f $(PROG_MOUNT_PATH)/mark_pod_ips_map ] || sudo bpftool map create $(PROG_MOUNT_PATH)/mark_pod_ips_map type hash key 4 value 16 entries 65535 name mark_pod_ips_map
 
 load-map-pair_original_dst:
-	[ -f $(TC_PINNING_PATH)/pair_original_dst ] || sudo bpftool map create $(TC_PINNING_PATH)/pair_original_dst type lru_hash key 12 value 12 entries 65535 name pair_original_dst
+	[ -f $(TC_PINNING_PATH)/pair_original_dst ] || sudo bpftool map create $(TC_PINNING_PATH)/pair_original_dst type lru_hash key 36 value 24 entries 65535 name pair_original_dst
 
 load-map-sock_pair_map:
-	[ -f $(PROG_MOUNT_PATH)/sock_pair_map ] || sudo bpftool map create $(PROG_MOUNT_PATH)/sock_pair_map type sockhash key 12 value 4 entries 65535 name sock_pair_map
+	[ -f $(PROG_MOUNT_PATH)/sock_pair_map ] || sudo bpftool map create $(PROG_MOUNT_PATH)/sock_pair_map type sockhash key 36 value 4 entries 65535 name sock_pair_map
 
 
 clean-maps:
@@ -124,18 +139,28 @@ clean-redir:
 	sudo rm $(PROG_MOUNT_PATH)/redir
 
 load-connect: load-map-cookie_original_dst load-map-local_pod_ips load-map-process_ip load-map-mark_pod_ips_map
-	sudo bpftool -m prog load mb_connect.o $(PROG_MOUNT_PATH)/connect \
+	sudo bpftool -m prog loadall mb_connect.o $(PROG_MOUNT_PATH)/connect \
 		map name cookie_original_dst pinned $(PROG_MOUNT_PATH)/cookie_original_dst \
 		map name local_pod_ips pinned $(TC_PINNING_PATH)/local_pod_ips \
 		map name mark_pod_ips_map pinned $(PROG_MOUNT_PATH)/mark_pod_ips_map \
 		map name process_ip pinned $(PROG_MOUNT_PATH)/process_ip
 
 attach-connect:
-	sudo bpftool cgroup attach $(CGROUP2_PATH) connect4 pinned $(PROG_MOUNT_PATH)/connect
+ifeq ($(ENABLE_IPV4),true)
+	sudo bpftool cgroup attach $(CGROUP2_PATH) connect4 pinned $(PROG_MOUNT_PATH)/connect/cgroup_connect4
+endif
+ifeq ($(ENABLE_IPV6),true)
+	sudo bpftool cgroup attach $(CGROUP2_PATH) connect6 pinned $(PROG_MOUNT_PATH)/connect/cgroup_connect6
+endif
 
 clean-connect:
-	sudo bpftool cgroup detach $(CGROUP2_PATH) connect4 pinned $(PROG_MOUNT_PATH)/connect
-	sudo rm $(PROG_MOUNT_PATH)/connect
+ifeq ($(ENABLE_IPV4),true)
+	sudo bpftool cgroup detach $(CGROUP2_PATH) connect4 pinned $(PROG_MOUNT_PATH)/connect/cgroup_connect4
+endif
+ifeq ($(ENABLE_IPV6),true)
+	sudo bpftool cgroup detach $(CGROUP2_PATH) connect6 pinned $(PROG_MOUNT_PATH)/connect/cgroup_connect6
+endif
+	sudo rm -rf $(PROG_MOUNT_PATH)/connect
 
 load-sockops: load-map-cookie_original_dst load-map-process_ip load-map-pair_original_dst load-map-sock_pair_map
 	sudo bpftool -m prog load mb_sockops.o $(PROG_MOUNT_PATH)/sockops \
@@ -152,36 +177,60 @@ clean-sockops:
 	sudo rm -rf $(PROG_MOUNT_PATH)/sockops
 
 load-bind:
+ifeq ($(ENABLE_IPV4),true)
 	sudo bpftool -m prog load mb_bind.o $(PROG_MOUNT_PATH)/bind
+endif
 
 attach-bind:
+ifeq ($(ENABLE_IPV4),true)
 	sudo bpftool cgroup attach $(CGROUP2_PATH) bind4 pinned $(PROG_MOUNT_PATH)/bind
+endif
 
 clean-bind:
+ifeq ($(ENABLE_IPV4),true)
 	sudo bpftool cgroup detach $(CGROUP2_PATH) bind4 pinned $(PROG_MOUNT_PATH)/bind
 	sudo rm -rf $(PROG_MOUNT_PATH)/bind
+endif
 
 load-sendmsg: load-map-cookie_original_dst
-	sudo bpftool -m prog load mb_sendmsg.o $(PROG_MOUNT_PATH)/sendmsg \
+	sudo bpftool -m prog loadall mb_sendmsg.o $(PROG_MOUNT_PATH)/sendmsg \
 		map name cookie_original_dst pinned $(PROG_MOUNT_PATH)/cookie_original_dst
 
 attach-sendmsg:
-	sudo bpftool cgroup attach $(CGROUP2_PATH) sendmsg4 pinned $(PROG_MOUNT_PATH)/sendmsg
+ifeq ($(ENABLE_IPV4),true)
+	sudo bpftool cgroup attach $(CGROUP2_PATH) sendmsg4 pinned $(PROG_MOUNT_PATH)/sendmsg/cgroup_sendmsg4
+endif
+ifeq ($(ENABLE_IPV6),true)
+	sudo bpftool cgroup attach $(CGROUP2_PATH) sendmsg6 pinned $(PROG_MOUNT_PATH)/sendmsg/cgroup_sendmsg6
+endif
 
 clean-sendmsg:
-	sudo bpftool cgroup detach $(CGROUP2_PATH) sendmsg4 pinned $(PROG_MOUNT_PATH)/sendmsg
-	sudo rm -rf $(PROG_MOUNT_PATH)/sendmsg
+ifeq ($(ENABLE_IPV4),true)
+	sudo bpftool cgroup detach $(CGROUP2_PATH) sendmsg4 pinned $(PROG_MOUNT_PATH)/sendmsg/cgroup_sendmsg4
+endif
+ifeq ($(ENABLE_IPV6),true)
+	sudo bpftool cgroup detach $(CGROUP2_PATH) sendmsg6 pinned $(PROG_MOUNT_PATH)/sendmsg/cgroup_sendmsg6
+endif
 
 load-recvmsg: load-map-cookie_original_dst
-	sudo bpftool -m prog load mb_recvmsg.o $(PROG_MOUNT_PATH)/recvmsg \
+	sudo bpftool -m prog loadall mb_recvmsg.o $(PROG_MOUNT_PATH)/recvmsg \
 		map name cookie_original_dst pinned $(PROG_MOUNT_PATH)/cookie_original_dst
 
 attach-recvmsg:
-	sudo bpftool cgroup attach $(CGROUP2_PATH) recvmsg4 pinned $(PROG_MOUNT_PATH)/recvmsg
+ifeq ($(ENABLE_IPV4),true)
+	sudo bpftool cgroup attach $(CGROUP2_PATH) recvmsg4 pinned $(PROG_MOUNT_PATH)/recvmsg/cgroup_recvmsg4
+endif
+ifeq ($(ENABLE_IPV6),true)
+	sudo bpftool cgroup attach $(CGROUP2_PATH) recvmsg6 pinned $(PROG_MOUNT_PATH)/recvmsg/cgroup_recvmsg6
+endif
 
 clean-recvmsg:
-	sudo bpftool cgroup detach $(CGROUP2_PATH) recvmsg4 pinned $(PROG_MOUNT_PATH)/recvmsg
-	sudo rm -rf $(PROG_MOUNT_PATH)/recvmsg
+ifeq ($(ENABLE_IPV4),true)
+	sudo bpftool cgroup detach $(CGROUP2_PATH) recvmsg4 pinned $(PROG_MOUNT_PATH)/recvmsg/cgroup_recvmsg4
+endif
+ifeq ($(ENABLE_IPV6),true)
+	sudo bpftool cgroup detach $(CGROUP2_PATH) recvmsg6 pinned $(PROG_MOUNT_PATH)/recvmsg/cgroup_recvmsg6
+endif
 
 load: compile load-from-obj
 

--- a/bpf/headers/helpers.h
+++ b/bpf/headers/helpers.h
@@ -17,8 +17,18 @@ limitations under the License.
 #include <linux/bpf.h>
 #include <linux/bpf_common.h>
 #include <linux/in.h>
+#include <linux/in6.h>
+#include <linux/socket.h>
 #include <linux/swab.h>
 #include <linux/types.h>
+
+#ifndef ENABLE_IPV4
+#define ENABLE_IPV4 1
+#endif
+
+#ifndef ENABLE_IPV6
+#define ENABLE_IPV6 0
+#endif
 
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 #define bpf_htons(x) __builtin_bswap16(x)
@@ -80,7 +90,7 @@ static long (*bpf_sock_hash_update)(
 static long (*bpf_msg_redirect_hash)(
     struct sk_msg_md *md, struct bpf_elf_map *map, void *key,
     __u64 flags) = (void *)BPF_FUNC_msg_redirect_hash;
-static long (*bpf_bind)(struct bpf_sock_addr *ctx, struct sockaddr_in *addr,
+static long (*bpf_bind)(struct bpf_sock_addr *ctx, struct sockaddr *addr,
                         int addr_len) = (void *)BPF_FUNC_bind;
 static long (*bpf_l4_csum_replace)(struct __sk_buff *skb, __u32 offset,
                                    __u64 from, __u64 to, __u64 flags) = (void *)
@@ -118,12 +128,28 @@ static long (*bpf_skb_store_bytes)(struct __sk_buff *skb, __u32 offset,
 
 #endif
 
+#ifndef memset
+#define memset(dst, src, len) __builtin_memset(dst, src, len)
+#endif
+
+static const __u32 ip_zero = 0;
+// 127.0.0.1 (network order)
+static const __u32 localhost = 127 + (1 << 24);
+
+static inline __u32 get_ipv4(__u32 *ip) { return ip[3]; }
+
+static inline void set_ipv4(__u32 *dst, __u32 src)
+{
+    __builtin_memset(dst, 0, sizeof(__u32) * 3);
+    dst[3] = src;
+}
+
 static inline int is_port_listen_current_ns(void *ctx, __u32 ip, __u16 port)
 {
 
     struct bpf_sock_tuple tuple = {};
     tuple.ipv4.dport = bpf_htons(port);
-    tuple.ipv4.daddr = bpf_htonl(ip);
+    tuple.ipv4.daddr = ip;
     struct bpf_sock *s = bpf_sk_lookup_tcp(ctx, &tuple, sizeof(tuple.ipv4),
                                            BPF_F_CURRENT_NETNS, 0);
     if (s) {
@@ -137,7 +163,7 @@ static inline int is_port_listen_udp_current_ns(void *ctx, __u32 ip, __u16 port)
 {
     struct bpf_sock_tuple tuple = {};
     tuple.ipv4.dport = bpf_htons(port);
-    tuple.ipv4.daddr = bpf_htonl(ip);
+    tuple.ipv4.daddr = ip;
     struct bpf_sock *s = bpf_sk_lookup_udp(ctx, &tuple, sizeof(tuple.ipv4),
                                            BPF_F_CURRENT_NETNS, 0);
     if (s) {
@@ -147,17 +173,63 @@ static inline int is_port_listen_udp_current_ns(void *ctx, __u32 ip, __u16 port)
     return 0;
 }
 
+static const __u32 ip_zero6[4] = {0, 0, 0, 0};
+// ::1 (network order)
+static const __u32 localhost6[4] = {0, 0, 0, 1 << 24};
+
+static inline void set_ipv6(__u32 *dst, __u32 *src)
+{
+    dst[0] = src[0];
+    dst[1] = src[1];
+    dst[2] = src[2];
+    dst[3] = src[3];
+}
+
+static inline int ipv6_equal(__u32 *a, __u32 *b)
+{
+    return a[0] == b[0] && a[1] == b[1] && a[2] == b[2] && a[3] == b[3];
+}
+
+static inline int is_port_listen_current_ns6(void *ctx, __u32 *ip, __u16 port)
+{
+    struct bpf_sock_tuple tuple = {};
+    tuple.ipv6.dport = bpf_htons(port);
+    set_ipv6(tuple.ipv6.daddr, ip);
+    struct bpf_sock *s = bpf_sk_lookup_tcp(ctx, &tuple, sizeof(tuple.ipv6),
+                                           BPF_F_CURRENT_NETNS, 0);
+    if (s) {
+        bpf_sk_release(s);
+        return 1;
+    }
+    return 0;
+}
+
+static inline int is_port_listen_udp_current_ns6(void *ctx, __u32 *ip,
+                                                 __u16 port)
+{
+    struct bpf_sock_tuple tuple = {};
+    tuple.ipv6.dport = bpf_htons(port);
+    set_ipv6(tuple.ipv6.daddr, ip);
+    struct bpf_sock *s = bpf_sk_lookup_udp(ctx, &tuple, sizeof(tuple.ipv6),
+                                           BPF_F_CURRENT_NETNS, 0);
+    if (s) {
+        bpf_sk_release(s);
+        return 1;
+    }
+    return 0;
+}
+
 struct origin_info {
+    __u32 ip[4];
     __u32 pid;
-    __u32 ip;
     __u16 port;
     // last bit means that ip of process is detected.
     __u16 flags;
 };
 
 struct pair {
-    __u32 sip;
-    __u32 dip;
+    __u32 sip[4];
+    __u32 dip[4];
     __u16 sport;
     __u16 dport;
 };

--- a/bpf/headers/helpers.h
+++ b/bpf/headers/helpers.h
@@ -140,7 +140,7 @@ static inline __u32 get_ipv4(__u32 *ip) { return ip[3]; }
 
 static inline void set_ipv4(__u32 *dst, __u32 src)
 {
-    __builtin_memset(dst, 0, sizeof(__u32) * 3);
+    memset(dst, 0, sizeof(__u32) * 3);
     dst[3] = src;
 }
 

--- a/bpf/headers/maps.h
+++ b/bpf/headers/maps.h
@@ -30,7 +30,7 @@ struct bpf_elf_map __section("maps") cookie_original_dst = {
 // only contains injected pods.
 struct bpf_elf_map __section("maps") local_pod_ips = {
     .type = BPF_MAP_TYPE_HASH,
-    .size_key = sizeof(__u32),
+    .size_key = sizeof(__u32) * 4,
     .size_value = sizeof(struct pod_config),
     .max_elem = 1024,
     .pinning = PIN_GLOBAL_NS,
@@ -62,6 +62,6 @@ struct bpf_elf_map __section("maps") sock_pair_map = {
 struct bpf_elf_map __section("maps") mark_pod_ips_map = {
     .type = BPF_MAP_TYPE_HASH,
     .size_key = sizeof(__u32),
-    .size_value = sizeof(__u32), // todo ipv6
+    .size_value = sizeof(__u32) * 4,
     .max_elem = 65535,
 };

--- a/bpf/headers/mesh.h
+++ b/bpf/headers/mesh.h
@@ -42,6 +42,11 @@ limitations under the License.
 #define DNS_CAPTURE_PORT 15053
 #endif
 
+// 127.0.0.6 (network order)
+static const __u32 envoy_ip = 127 + (6 << 24);
+// ::6 (network order)
+static const __u32 envoy_ip6[4] = {0, 0, 0, 6 << 24};
+
 #elif MESH == LINKERD
 
 #ifndef OUT_REDIRECT_PORT
@@ -60,6 +65,11 @@ limitations under the License.
 #define DNS_CAPTURE_PORT 0 // todo fix me
 #endif
 
+// 127.0.0.6 (network order)
+static const __u32 envoy_ip = 127 + (6 << 24);
+// ::6 (network order)
+static const __u32 envoy_ip6[4] = {0, 0, 0, 6 << 24};
+
 #elif MESH == KUMA
 
 #ifndef OUT_REDIRECT_PORT
@@ -77,6 +87,11 @@ limitations under the License.
 #ifndef DNS_CAPTURE_PORT
 #define DNS_CAPTURE_PORT 15053
 #endif
+
+// 127.0.0.6 (network order)
+static const __u32 envoy_ip = 127 + (6 << 24);
+// ::6 (network order)
+static const __u32 envoy_ip6[4] = {0, 0, 0, 6 << 24};
 
 #else
 #error "Mesh mode not supported yet"

--- a/bpf/mb_bind.c
+++ b/bpf/mb_bind.c
@@ -21,6 +21,7 @@ limitations under the License.
 // this prog hook linkerd bind OUTPUT_LISTENER
 // which will makes the listen address change from 127.0.0.1:4140 to
 // 0.0.0.0:4140
+#if ENABLE_IPV4
 __section("cgroup/bind4") int mb_bind(struct bpf_sock_addr *ctx)
 {
 #if MESH != LINKERD
@@ -41,6 +42,7 @@ __section("cgroup/bind4") int mb_bind(struct bpf_sock_addr *ctx)
     }
     return 1;
 }
+#endif
 
 char ____license[] __section("license") = "GPL";
 int _version __section("version") = 1;

--- a/bpf/mb_connect.c
+++ b/bpf/mb_connect.c
@@ -330,9 +330,9 @@ static inline int tcp_connect6(struct bpf_sock_addr *ctx)
 
     // get ip addresses of current pod/ns.
     struct bpf_sock_tuple tuple = {};
-    tuple.ipv4.dport = bpf_htons(SOCK_IP_MARK_PORT);
-    tuple.ipv4.daddr = 0;
-    struct bpf_sock *s = bpf_sk_lookup_tcp(ctx, &tuple, sizeof(tuple.ipv4),
+    tuple.ipv6.dport = bpf_htons(SOCK_IP_MARK_PORT);
+    set_ipv6(tuple.ipv6.daddr, ip_zero6);
+    struct bpf_sock *s = bpf_sk_lookup_tcp(ctx, &tuple, sizeof(tuple.ipv6),
                                            BPF_F_CURRENT_NETNS, 0);
     if (!s) {
         // cni mode required for ipv6

--- a/bpf/mb_connect.c
+++ b/bpf/mb_connect.c
@@ -19,80 +19,89 @@ limitations under the License.
 #include <linux/bpf.h>
 #include <linux/in.h>
 
+#if ENABLE_IPV4
 static __u32 outip = 1;
 
-static inline int udp4_connect(struct bpf_sock_addr *ctx)
+static inline int udp_connect4(struct bpf_sock_addr *ctx)
 {
-
 #if MESH != ISTIO && MESH != KUMA
     // only works on istio and kuma
     return 1;
 #endif
-    if (!(is_port_listen_current_ns(ctx, 0, OUT_REDIRECT_PORT) &&
-          is_port_listen_udp_current_ns(ctx, 0x7f000001, DNS_CAPTURE_PORT))) {
+    if (bpf_htons(ctx->user_port) != 53) {
+        return 1;
+    }
+    if (!(is_port_listen_current_ns(ctx, ip_zero, OUT_REDIRECT_PORT) &&
+          is_port_listen_udp_current_ns(ctx, localhost, DNS_CAPTURE_PORT))) {
         // this query is not from mesh injected pod, or DNS CAPTURE not enabled.
         // we do nothing.
         return 1;
     }
-    __u64 cookie = bpf_get_socket_cookie_addr(ctx);
+
     __u64 uid = bpf_get_current_uid_gid() & 0xffffffff;
-    if (bpf_htons(ctx->user_port) == 53 && uid != SIDECAR_USER_ID) {
+    if (uid != SIDECAR_USER_ID) {
         // needs rewrite
-        struct origin_info origin = {.ip = ctx->user_ip4,
-                                     .port = ctx->user_port};
+        struct origin_info origin;
+        memset(&origin, 0, sizeof(origin));
+        set_ipv4(origin.ip, ctx->user_ip4);
+        origin.port = ctx->user_port;
         // save original dst
+        __u64 cookie = bpf_get_socket_cookie_addr(ctx);
         if (bpf_map_update_elem(&cookie_original_dst, &cookie, &origin,
                                 BPF_ANY)) {
             printk("update origin cookie failed: %d", cookie);
         }
         ctx->user_port = bpf_htons(DNS_CAPTURE_PORT);
-        ctx->user_ip4 = 0x100007f;
+        ctx->user_ip4 = localhost;
     }
     return 1;
 }
 
-static inline int tcp4_connect(struct bpf_sock_addr *ctx)
+static inline int tcp_connect4(struct bpf_sock_addr *ctx)
 {
     // todo(kebe7jun) more reliable way to verify,
-    if (!is_port_listen_current_ns(ctx, 0, OUT_REDIRECT_PORT)) {
+    if (!is_port_listen_current_ns(ctx, ip_zero, OUT_REDIRECT_PORT)) {
         // bypass normal traffic.
         // we only deal pod's traffic managed by istio or kuma.
         return 1;
     }
     __u32 curr_pod_ip = 0;
+    __u32 _curr_pod_ip[4];
     {
         // get ip addresses of current pod/ns.
-        __u32 curr_ip_mark = 0;
         struct bpf_sock_tuple tuple = {};
         tuple.ipv4.dport = bpf_htons(SOCK_IP_MARK_PORT);
         tuple.ipv4.daddr = 0;
         struct bpf_sock *s = bpf_sk_lookup_tcp(ctx, &tuple, sizeof(tuple.ipv4),
                                                BPF_F_CURRENT_NETNS, 0);
         if (s) {
-            curr_ip_mark = s->mark;
+            __u32 curr_ip_mark = s->mark;
             bpf_sk_release(s);
             __u32 *ip = bpf_map_lookup_elem(&mark_pod_ips_map, &curr_ip_mark);
             if (ip) {
-                curr_pod_ip = *ip; // network order
+                set_ipv6(_curr_pod_ip, ip); // network order
+                curr_pod_ip = get_ipv4(ip);
             } else {
                 debugf("get ip for mark %x error", curr_ip_mark);
             }
         }
     }
+
     if (curr_pod_ip == 0) {
         debugf("get current pod ip error");
     }
     __u64 uid = bpf_get_current_uid_gid() & 0xffffffff;
     __u32 pid;
+    __u32 dst_ip = ctx->user_ip4;
     if (uid != SIDECAR_USER_ID) {
-        if ((ctx->user_ip4 & 0xff) == 0x7f) {
+        if ((dst_ip & 0xff) == 0x7f) {
             // app call local, bypass.
             return 1;
         }
         __u64 cookie = bpf_get_socket_cookie_addr(ctx);
         // app call others
-        debugf("call from user container: cookie: %d, ip: 0x%x, port: %d",
-               cookie, ctx->user_ip4, bpf_htons(ctx->user_port));
+        debugf("call from user container: cookie: %d, ip: %pI4, port: %d",
+               cookie, &dst_ip, bpf_htons(ctx->user_port));
         // u64 bpf_get_current_pid_tgid(void)
         // Return A 64-bit integer containing the current tgid and
         //                 pid, and created as such: current_task->tgid << 32
@@ -100,61 +109,60 @@ static inline int tcp4_connect(struct bpf_sock_addr *ctx)
         // pid may be thread id, we should use tgid
         pid = bpf_get_current_pid_tgid() >> 32; // tgid
         // we need redirect it to envoy.
-        struct origin_info origin = {
-            .ip = ctx->user_ip4,
-            .port = ctx->user_port,
-            .pid = pid,
-            .flags = 1,
-        };
+        struct origin_info origin;
+        memset(&origin, 0, sizeof(origin));
+        set_ipv4(origin.ip, dst_ip);
+        origin.port = ctx->user_port;
+        origin.pid = pid;
+        origin.flags = 1;
         if (bpf_map_update_elem(&cookie_original_dst, &cookie, &origin,
                                 BPF_ANY)) {
             printk("write cookie_original_dst failed");
             return 0;
         }
         if (curr_pod_ip) {
-            __u32 ip = curr_pod_ip;
-            struct pod_config *pod = bpf_map_lookup_elem(&local_pod_ips, &ip);
+            struct pod_config *pod =
+                bpf_map_lookup_elem(&local_pod_ips, _curr_pod_ip);
             if (pod) {
                 int exclude = 0;
                 IS_EXCLUDE_PORT(pod->exclude_out_ports, ctx->user_port,
                                 &exclude);
                 if (exclude) {
                     debugf("ignored dest port by exclude_out_ports, ip: "
-                           "%x, port: %d",
-                           ip, bpf_htons(ctx->user_port));
+                           "%pI4, port: %d",
+                           &curr_pod_ip, bpf_htons(ctx->user_port));
                     return 1;
                 }
-                IS_EXCLUDE_IPRANGES(pod->exclude_out_ranges, ctx->user_ip4,
-                                    &exclude);
+                IS_EXCLUDE_IPRANGES(pod->exclude_out_ranges, dst_ip, &exclude);
                 debugf("exclude ipranges: %x, exclude: %d",
                        pod->exclude_out_ranges[0].net, exclude);
                 if (exclude) {
-                    debugf("ignored dest ranges by exclude_out_ranges, ip: %x",
-                           ctx->user_ip4);
+                    debugf(
+                        "ignored dest ranges by exclude_out_ranges, ip: %pI4",
+                        &dst_ip);
                     return 1;
                 }
                 int include = 0;
                 IS_INCLUDE_PORT(pod->include_out_ports, ctx->user_port,
                                 &include);
                 if (!include) {
-                    debugf("dest port %d not in pod(%x)'s include_out_ports, "
+                    debugf("dest port %d not in pod(%pI4)'s include_out_ports, "
                            "ignored.",
-                           bpf_htons(ctx->user_port), ip);
+                           bpf_htons(ctx->user_port), &curr_pod_ip);
                     return 1;
                 }
 
-                IS_INCLUDE_IPRANGES(pod->include_out_ranges, ctx->user_ip4,
-                                    &include);
+                IS_INCLUDE_IPRANGES(pod->include_out_ranges, dst_ip, &include);
                 if (!include) {
-                    debugf(
-                        "dest %x not in pod(%x)'s include_out_ranges, ignored.",
-                        ctx->user_ip4, ip);
+                    debugf("dest %pI4 not in pod(%pI4)'s include_out_ranges, "
+                           "ignored.",
+                           &dst_ip, &curr_pod_ip);
                     return 1;
                 }
             } else {
-                debugf("current pod ip found(%x), but can not find pod_info "
+                debugf("current pod ip found(%pI4), but can not find pod_info "
                        "from local_pod_ips",
-                       curr_pod_ip);
+                       &curr_pod_ip);
             }
             // todo port or ipranges ignore.
             // if we can get the pod ip, we use bind func to bind the pod's ip
@@ -163,10 +171,11 @@ static inline int tcp4_connect(struct bpf_sock_addr *ctx)
             addr.sin_addr.s_addr = curr_pod_ip;
             addr.sin_port = 0;
             addr.sin_family = 2;
-            if (bpf_bind(ctx, &addr, sizeof(struct sockaddr_in))) {
-                printk("bind %x error", curr_pod_ip);
+            if (bpf_bind(ctx, (struct sockaddr *)&addr,
+                         sizeof(struct sockaddr_in))) {
+                printk("bind %pI4 error", &curr_pod_ip);
             }
-            ctx->user_ip4 = bpf_htonl(0x7f000001);
+            ctx->user_ip4 = localhost;
         } else {
             // if we can not get the pod ip, we rewrite the dest address.
             // The reason we try the IP of the 127.128.0.0/20 segment instead of
@@ -182,47 +191,46 @@ static inline int tcp4_connect(struct bpf_sock_addr *ctx)
     } else {
         __u64 cookie = bpf_get_socket_cookie_addr(ctx);
         // from envoy to others
-        debugf("call from sidecar container: cookie: %d, ip: 0x%x, port: %d",
-               cookie, ctx->user_ip4, bpf_htons(ctx->user_port));
-        __u32 ip = ctx->user_ip4;
-        if (!bpf_map_lookup_elem(&local_pod_ips, &ip)) {
+        debugf("call from sidecar container: cookie: %d, ip: %pI4, port: %d",
+               cookie, &dst_ip, bpf_htons(ctx->user_port));
+        __u32 _dst_ip[4];
+        set_ipv4(_dst_ip, dst_ip);
+        struct pod_config *pod = bpf_map_lookup_elem(&local_pod_ips, _dst_ip);
+        if (!pod) {
             // dst ip is not in this node, bypass
-            debugf("dest ip: 0x%x not in this node, bypass", ctx->user_ip4);
+            debugf("dest ip: %pI4 not in this node, bypass", &dst_ip);
             return 1;
         }
         pid = bpf_get_current_pid_tgid() >> 32;
         // dst ip is in this node, but not the current pod,
         // it is envoy to envoy connecting.
-        struct origin_info origin = {
-            .ip = ctx->user_ip4,
-            .port = ctx->user_port,
-            .pid = pid,
-        };
+        struct origin_info origin;
+        memset(&origin, 0, sizeof(origin));
+        set_ipv4(origin.ip, dst_ip);
+        origin.port = ctx->user_port;
+        origin.pid = pid;
+
         if (curr_pod_ip) {
             origin.flags |= 1;
-            if (curr_pod_ip != ip) {
+            if (curr_pod_ip != dst_ip) {
                 // call other pod, need redirect port.
-                struct pod_config *pod =
-                    bpf_map_lookup_elem(&local_pod_ips, &ip);
-                if (pod) {
-                    int exclude = 0;
-                    IS_EXCLUDE_PORT(pod->exclude_in_ports, ctx->user_port,
-                                    &exclude);
-                    if (exclude) {
-                        debugf("ignored dest port by exclude_in_ports, ip: %x, "
-                               "port: %d",
-                               ip, bpf_htons(ctx->user_port));
-                        return 1;
-                    }
-                    int include = 0;
-                    IS_INCLUDE_PORT(pod->include_in_ports, ctx->user_port,
-                                    &include);
-                    if (!include) {
-                        debugf("ignored dest port by include_in_ports, ip: %x, "
-                               "port: %d",
-                               ip, bpf_htons(ctx->user_port));
-                        return 1;
-                    }
+                int exclude = 0;
+                IS_EXCLUDE_PORT(pod->exclude_in_ports, ctx->user_port,
+                                &exclude);
+                if (exclude) {
+                    debugf("ignored dest port by exclude_in_ports, ip: %pI4, "
+                           "port: %d",
+                           &dst_ip, bpf_htons(ctx->user_port));
+                    return 1;
+                }
+                int include = 0;
+                IS_INCLUDE_PORT(pod->include_in_ports, ctx->user_port,
+                                &include);
+                if (!include) {
+                    debugf("ignored dest port by include_in_ports, ip: %pI4, "
+                           "port: %d",
+                           &dst_ip, bpf_htons(ctx->user_port));
+                    return 1;
                 }
                 ctx->user_port = bpf_htons(IN_REDIRECT_PORT);
             }
@@ -231,7 +239,7 @@ static inline int tcp4_connect(struct bpf_sock_addr *ctx)
             void *curr_ip = bpf_map_lookup_elem(&process_ip, &pid);
             if (curr_ip) {
                 // envoy to other envoy
-                if (*(__u32 *)curr_ip != ctx->user_ip4) {
+                if (*(__u32 *)curr_ip != dst_ip) {
                     debugf("enovy to other, rewrite dst port from %d to %d",
                            ctx->user_port, IN_REDIRECT_PORT);
                     ctx->user_port = bpf_htons(IN_REDIRECT_PORT);
@@ -262,17 +270,165 @@ static inline int tcp4_connect(struct bpf_sock_addr *ctx)
     return 1;
 }
 
-__section("cgroup/connect4") int mb_sock4_connect(struct bpf_sock_addr *ctx)
+__section("cgroup/connect4") int mb_sock_connect4(struct bpf_sock_addr *ctx)
 {
     switch (ctx->protocol) {
     case IPPROTO_TCP:
-        return tcp4_connect(ctx);
+        return tcp_connect4(ctx);
     case IPPROTO_UDP:
-        return udp4_connect(ctx);
+        return udp_connect4(ctx);
     default:
         return 1;
     }
 }
+#endif
+
+#if ENABLE_IPV6
+static inline int udp_connect6(struct bpf_sock_addr *ctx)
+{
+#if MESH != ISTIO && MESH != KUMA
+    // only works on istio and kuma
+    return 1;
+#endif
+    if (bpf_htons(ctx->user_port) != 53) {
+        return 1;
+    }
+    if (!(is_port_listen_current_ns6(ctx, ip_zero6, OUT_REDIRECT_PORT) &&
+          is_port_listen_udp_current_ns6(ctx, localhost6, DNS_CAPTURE_PORT))) {
+        // this query is not from mesh injected pod, or DNS CAPTURE not enabled.
+        // we do nothing.
+        return 1;
+    }
+
+    __u64 uid = bpf_get_current_uid_gid() & 0xffffffff;
+    if (uid != SIDECAR_USER_ID) {
+        // needs rewrite
+        struct origin_info origin;
+        memset(&origin, 0, sizeof(origin));
+        set_ipv6(origin.ip, ctx->user_ip6);
+        origin.port = ctx->user_port;
+        // save original dst
+        __u64 cookie = bpf_get_socket_cookie_addr(ctx);
+        if (bpf_map_update_elem(&cookie_original_dst, &cookie, &origin,
+                                BPF_ANY)) {
+            printk("update origin cookie failed: %d", cookie);
+        }
+        ctx->user_port = bpf_htons(DNS_CAPTURE_PORT);
+        set_ipv6(ctx->user_ip6, localhost6);
+    }
+    return 1;
+}
+
+static inline int tcp_connect6(struct bpf_sock_addr *ctx)
+{
+    // todo(kebe7jun) more reliable way to verify,
+    if (!is_port_listen_current_ns6(ctx, ip_zero6, OUT_REDIRECT_PORT)) {
+        // bypass normal traffic.
+        // we only deal pod's traffic managed by istio or kuma.
+        return 1;
+    }
+
+    // get ip addresses of current pod/ns.
+    struct bpf_sock_tuple tuple = {};
+    tuple.ipv4.dport = bpf_htons(SOCK_IP_MARK_PORT);
+    tuple.ipv4.daddr = 0;
+    struct bpf_sock *s = bpf_sk_lookup_tcp(ctx, &tuple, sizeof(tuple.ipv4),
+                                           BPF_F_CURRENT_NETNS, 0);
+    if (!s) {
+        // cni mode required for ipv6
+        debugf("dummy socket not found");
+        return 1;
+    }
+
+    __u32 curr_ip_mark = s->mark;
+    bpf_sk_release(s);
+    __u32 *ip = bpf_map_lookup_elem(&mark_pod_ips_map, &curr_ip_mark);
+    if (!ip) {
+        debugf("get ip for mark %x error", curr_ip_mark);
+        return 1;
+    }
+    __u32 curr_pod_ip[4];
+    set_ipv6(curr_pod_ip, ip);
+    __u32 dst_ip[4];
+    set_ipv6(dst_ip, ctx->user_ip6);
+    __u64 uid = bpf_get_current_uid_gid() & 0xffffffff;
+    if (uid != SIDECAR_USER_ID) {
+        if (ipv6_equal(dst_ip, localhost6)) {
+            // app call local, bypass.
+            return 1;
+        }
+        __u64 cookie = bpf_get_socket_cookie_addr(ctx);
+        // app call others
+        debugf("call from user container: cookie: %d, ip: %pI6c, port: %d",
+               cookie, dst_ip, bpf_htons(ctx->user_port));
+
+        // we need redirect it to envoy.
+        struct origin_info origin;
+        memset(&origin, 0, sizeof(origin));
+        set_ipv6(origin.ip, dst_ip);
+        origin.port = ctx->user_port;
+
+        if (bpf_map_update_elem(&cookie_original_dst, &cookie, &origin,
+                                BPF_ANY)) {
+            printk("write cookie_original_dst failed");
+            return 0;
+        }
+        // TODO(dddddai): add support for annotations
+
+        // if we can get the pod ip, we use bind func to bind the pod's ip
+        // as the source ip to avoid quaternions conflict of different pods.
+        struct sockaddr_in6 addr;
+        set_ipv6(addr.sin6_addr.in6_u.u6_addr32, curr_pod_ip);
+        addr.sin6_port = 0;
+        addr.sin6_family = 10;
+        if (bpf_bind(ctx, (struct sockaddr *)&addr,
+                     sizeof(struct sockaddr_in6))) {
+            printk("bind %pI6c error", curr_pod_ip);
+        }
+        set_ipv6(ctx->user_ip6, localhost6);
+        ctx->user_port = bpf_htons(OUT_REDIRECT_PORT);
+    } else {
+        __u64 cookie = bpf_get_socket_cookie_addr(ctx);
+        // from envoy to others
+        debugf("call from sidecar container: cookie: %d, ip: %pI6c, port: %d",
+               cookie, dst_ip, bpf_htons(ctx->user_port));
+        if (!bpf_map_lookup_elem(&local_pod_ips, dst_ip)) {
+            // dst ip is not in this node, bypass
+            debugf("dest ip: %pI6c not in this node, bypass", dst_ip);
+            return 1;
+        }
+        // dst ip is in this node, but not the current pod,
+        // it is envoy to envoy connecting.
+        struct origin_info origin;
+        memset(&origin, 0, sizeof(origin));
+        origin.port = ctx->user_port;
+        set_ipv6(origin.ip, dst_ip);
+        if (!ipv6_equal(dst_ip, curr_pod_ip)) {
+            debugf("enovy to other, rewrite dst port from %d to %d",
+                   ctx->user_port, bpf_htons(IN_REDIRECT_PORT));
+            ctx->user_port = bpf_htons(IN_REDIRECT_PORT);
+        }
+        if (bpf_map_update_elem(&cookie_original_dst, &cookie, &origin,
+                                BPF_NOEXIST)) {
+            printk("update cookie origin failed");
+            return 0;
+        }
+    }
+    return 1;
+}
+
+__section("cgroup/connect6") int mb_sock_connect6(struct bpf_sock_addr *ctx)
+{
+    switch (ctx->protocol) {
+    case IPPROTO_TCP:
+        return tcp_connect6(ctx);
+    case IPPROTO_UDP:
+        return udp_connect6(ctx);
+    default:
+        return 1;
+    }
+}
+#endif
 
 char ____license[] __section("license") = "GPL";
 int _version __section("version") = 1;

--- a/bpf/mb_sockops.c
+++ b/bpf/mb_sockops.c
@@ -19,27 +19,30 @@ limitations under the License.
 #include <linux/bpf.h>
 #include <linux/in.h>
 
+#if ENABLE_IPV4
 static inline int sockops_ipv4(struct bpf_sock_ops *skops)
 {
     __u64 cookie = bpf_get_socket_cookie_ops(skops);
 
-    struct pair p = {
-        .sip = skops->local_ip4,
-        .sport = bpf_htons(skops->local_port),
-        .dip = skops->remote_ip4,
-        .dport = skops->remote_port >> 16,
-    };
-    void *dst = bpf_map_lookup_elem(&cookie_original_dst, &cookie);
+    struct pair p;
+    memset(&p, 0, sizeof(p));
+    set_ipv4(p.sip, skops->local_ip4);
+    p.sport = bpf_htons(skops->local_port);
+    set_ipv4(p.dip, skops->remote_ip4);
+    p.dport = skops->remote_port >> 16;
+
+    struct origin_info *dst =
+        bpf_map_lookup_elem(&cookie_original_dst, &cookie);
     if (dst) {
-        struct origin_info dd = *(struct origin_info *)dst;
+        struct origin_info dd = *dst;
         if (!(dd.flags & 1)) {
             __u32 pid = dd.pid;
             // process ip not detected
-            if (skops->local_ip4 == 100663423 ||
+            if (skops->local_ip4 == envoy_ip ||
                 skops->local_ip4 == skops->remote_ip4) {
                 // envoy to local
                 __u32 ip = skops->remote_ip4;
-                debugf("detected process %d's ip is %d", pid, ip);
+                debugf("detected process %d's ip is %pI4", pid, &ip);
                 bpf_map_update_elem(&process_ip, &pid, &ip, BPF_ANY);
 #ifdef USE_RECONNECT
                 if (skops->remote_port >> 16 == bpf_htons(IN_REDIRECT_PORT)) {
@@ -51,42 +54,69 @@ static inline int sockops_ipv4(struct bpf_sock_ops *skops)
                 // envoy to envoy
                 __u32 ip = skops->local_ip4;
                 bpf_map_update_elem(&process_ip, &pid, &ip, BPF_ANY);
-                debugf("detected process %d's ip is %d", pid, ip);
+                debugf("detected process %d's ip is %pI4", pid, &ip);
             }
         }
         // get_sockopts can read pid and cookie,
         // we should write a new map named pair_original_dst
         bpf_map_update_elem(&pair_original_dst, &p, &dd, BPF_ANY);
         bpf_sock_hash_update(skops, &sock_pair_map, &p, BPF_NOEXIST);
-    } else {
-        if (skops->local_port == OUT_REDIRECT_PORT ||
-            skops->local_port == IN_REDIRECT_PORT ||
-            skops->remote_ip4 == 100663423) {
-            bpf_sock_hash_update(skops, &sock_pair_map, &p, BPF_NOEXIST);
-        }
+    } else if (skops->local_port == OUT_REDIRECT_PORT ||
+               skops->local_port == IN_REDIRECT_PORT ||
+               skops->remote_ip4 == envoy_ip) {
+        bpf_sock_hash_update(skops, &sock_pair_map, &p, BPF_NOEXIST);
     }
     return 0;
 }
+#endif
+
+#if ENABLE_IPV6
+static inline int sockops_ipv6(struct bpf_sock_ops *skops)
+{
+    __u64 cookie = bpf_get_socket_cookie_ops(skops);
+    struct pair p;
+    memset(&p, 0, sizeof(p));
+    p.sport = bpf_htons(skops->local_port);
+    p.dport = skops->remote_port >> 16;
+    set_ipv6(p.sip, skops->local_ip6);
+    set_ipv6(p.dip, skops->remote_ip6);
+
+    struct origin_info *dst =
+        bpf_map_lookup_elem(&cookie_original_dst, &cookie);
+    if (dst) {
+        struct origin_info dd = *dst;
+        // get_sockopts can read pid and cookie,
+        // we should write a new map named pair_original_dst
+        bpf_map_update_elem(&pair_original_dst, &p, &dd, BPF_ANY);
+        bpf_sock_hash_update(skops, &sock_pair_map, &p, BPF_NOEXIST);
+    } else if (skops->local_port == OUT_REDIRECT_PORT ||
+               skops->local_port == IN_REDIRECT_PORT ||
+               ipv6_equal(skops->remote_ip6, envoy_ip6)) {
+        bpf_sock_hash_update(skops, &sock_pair_map, &p, BPF_NOEXIST);
+    }
+    return 0;
+}
+#endif
 
 __section("sockops") int mb_sockops(struct bpf_sock_ops *skops)
 {
-    __u32 family, op;
-    family = skops->family;
-    op = skops->op;
-
-    switch (op) {
+    switch (skops->op) {
     case BPF_SOCK_OPS_PASSIVE_ESTABLISHED_CB:
     case BPF_SOCK_OPS_ACTIVE_ESTABLISHED_CB:
-        if (family == 2) { // AFI_NET, we dont include socket.h, because it may
-                           // cause an import error.
-            if (sockops_ipv4(skops))
-                return 1;
-            else
-                return 0;
+        switch (skops->family) {
+#if ENABLE_IPV4
+        case 2:
+            // AF_INET, we don't include socket.h, because it may
+            // cause an import error.
+            return sockops_ipv4(skops);
+#endif
+#if ENABLE_IPV6
+        case 10:
+            // AF_INET6
+            return sockops_ipv6(skops);
+#endif
         }
-        break;
-    default:
-        break;
+        return 0;
     }
     return 0;
 }

--- a/bpf/mb_tc.c
+++ b/bpf/mb_tc.c
@@ -21,18 +21,10 @@ limitations under the License.
 #include <linux/if_ether.h>
 #include <linux/in.h>
 #include <linux/ip.h>
+#include <linux/ipv6.h>
 #include <linux/pkt_cls.h>
 #include <linux/tcp.h>
 #import <stddef.h>
-
-#define TCP_CSUM_OFF                                                           \
-    (ETH_HLEN + sizeof(struct iphdr) + offsetof(struct tcphdr, check))
-
-#define TCP_SPORT_OFF                                                          \
-    (ETH_HLEN + sizeof(struct iphdr) + offsetof(struct tcphdr, source))
-
-#define TCP_DPORT_OFF                                                          \
-    (ETH_HLEN + sizeof(struct iphdr) + offsetof(struct tcphdr, dest))
 
 __section("classifier_ingress") int mb_tc_ingress(struct __sk_buff *skb)
 {
@@ -42,31 +34,65 @@ __section("classifier_ingress") int mb_tc_ingress(struct __sk_buff *skb)
     if ((void *)(eth + 1) > data_end) {
         return TC_ACT_SHOT;
     }
-    if (bpf_htons(eth->h_proto) != ETH_P_IP) {
-        return TC_ACT_OK;
-    }
 
-    struct iphdr *iph = (struct iphdr *)(eth + 1);
-    if ((void *)(iph + 1) > data_end) {
-        return TC_ACT_SHOT;
-    }
+    __u32 src_ip[4];
+    __u32 dst_ip[4];
+    struct tcphdr *tcph;
+    __u32 csum_off;
+    __u32 dport_off;
 
-    if (iph->protocol == IPPROTO_IPIP) {
-        iph = ((void *)iph + iph->ihl * 4);
+    switch (bpf_htons(eth->h_proto)) {
+#if ENABLE_IPV4
+    case ETH_P_IP: {
+        struct iphdr *iph = (struct iphdr *)(eth + 1);
         if ((void *)(iph + 1) > data_end) {
+            return TC_ACT_SHOT;
+        }
+        if (iph->protocol == IPPROTO_IPIP) {
+            iph = ((void *)iph + iph->ihl * 4);
+            if ((void *)(iph + 1) > data_end) {
+                return TC_ACT_OK;
+            }
+        }
+        if (iph->protocol != IPPROTO_TCP) {
             return TC_ACT_OK;
         }
+        set_ipv4(src_ip, iph->saddr);
+        set_ipv4(dst_ip, iph->daddr);
+        tcph = (struct tcphdr *)(iph + 1);
+        csum_off =
+            ETH_HLEN + sizeof(struct iphdr) + offsetof(struct tcphdr, check);
+        dport_off =
+            ETH_HLEN + sizeof(struct iphdr) + offsetof(struct tcphdr, dest);
+        break;
     }
-
-    if (iph->protocol != IPPROTO_TCP) {
+#endif
+#if ENABLE_IPV6
+    case ETH_P_IPV6: {
+        struct ipv6hdr *iph = (struct ipv6hdr *)(eth + 1);
+        if ((void *)(iph + 1) > data_end) {
+            return TC_ACT_SHOT;
+        }
+        if (iph->nexthdr != IPPROTO_TCP) {
+            return TC_ACT_OK;
+        }
+        set_ipv6(src_ip, iph->saddr.in6_u.u6_addr32);
+        set_ipv6(dst_ip, iph->daddr.in6_u.u6_addr32);
+        tcph = (struct tcphdr *)(iph + 1);
+        csum_off =
+            ETH_HLEN + sizeof(struct ipv6hdr) + offsetof(struct tcphdr, check);
+        dport_off =
+            ETH_HLEN + sizeof(struct ipv6hdr) + offsetof(struct tcphdr, dest);
+        break;
+    }
+#endif
+    default:
         return TC_ACT_OK;
     }
 
-    struct tcphdr *tcph = (struct tcphdr *)(iph + 1);
     if ((void *)(tcph + 1) > data_end) {
         return TC_ACT_SHOT;
     }
-
     __u16 in_port = bpf_htons(IN_REDIRECT_PORT);
     if (tcph->syn && !tcph->ack) {
         // first packet
@@ -77,8 +103,7 @@ __section("classifier_ingress") int mb_tc_ingress(struct __sk_buff *skb)
             return TC_ACT_OK;
         }
         // ingress without mb_connect
-        __u32 ip = iph->daddr;
-        struct pod_config *pod = bpf_map_lookup_elem(&local_pod_ips, &ip);
+        struct pod_config *pod = bpf_map_lookup_elem(&local_pod_ips, dst_ip);
         if (!pod) {
             // dest ip is not on this node or not injected sidecar.
             debugf("tc ingress: pod not found, bypassed");
@@ -90,54 +115,57 @@ __section("classifier_ingress") int mb_tc_ingress(struct __sk_buff *skb)
         int exclude = 0;
         IS_EXCLUDE_PORT(pod->exclude_in_ports, tcph->dest, &exclude);
         if (exclude) {
-            debugf("ignored dest port by exclude_in_ports, ip: %x, port: %d",
-                   iph->daddr, bpf_htons(tcph->dest));
+            debugf("ignored dest port by exclude_in_ports, ip: %pI4/%pI6c, "
+                   "port: %d",
+                   &dst_ip[3], dst_ip, bpf_htons(tcph->dest));
             return TC_ACT_OK;
         }
         int include = 0;
         IS_INCLUDE_PORT(pod->include_in_ports, tcph->dest, &include);
         if (!include) {
-            debugf("ignored dest port by include_in_ports, ip: %x, port: %d",
-                   iph->daddr, bpf_htons(tcph->dest));
+            debugf("ignored dest port by include_in_ports, ip: %pI4/%pI6c, "
+                   "port: %d",
+                   &dst_ip[3], dst_ip, bpf_htons(tcph->dest));
             return TC_ACT_OK;
         }
 
         // like from 10.0.0.1:23456 => 172.31.0.123:80
         // we will rewrite the dest port from 80 to 15006
         // which will be: 10.0.0.1:23456 => 172.31.0.123:15006
-        struct pair p = {
-            .sip = iph->saddr,
-            .sport = tcph->source,
-            .dip = iph->daddr,
-            .dport = in_port,
-        };
-        struct origin_info origin = {
-            .ip = iph->daddr,
-            .port = tcph->dest,
-            .flags = TC_ORIGIN_FLAG,
-        };
-        bpf_map_update_elem(&pair_original_dst, &p, &origin, BPF_NOEXIST);
+        struct pair p;
+        memset(&p, 0, sizeof(p));
+        set_ipv6(p.sip, src_ip);
+        set_ipv6(p.dip, dst_ip);
+        p.sport = tcph->source;
+        p.dport = in_port;
+
         __u16 dst_port = tcph->dest;
-        bpf_l4_csum_replace(skb, TCP_CSUM_OFF, dst_port, in_port,
-                            sizeof(dst_port));
-        bpf_skb_store_bytes(skb, TCP_DPORT_OFF, &in_port, sizeof(in_port), 0);
+        struct origin_info origin;
+        memset(&origin, 0, sizeof(origin));
+        set_ipv6(origin.ip, dst_ip);
+        origin.port = dst_port;
+        origin.flags = TC_ORIGIN_FLAG;
+        bpf_map_update_elem(&pair_original_dst, &p, &origin, BPF_NOEXIST);
+
+        bpf_l4_csum_replace(skb, csum_off, dst_port, in_port, sizeof(dst_port));
+        bpf_skb_store_bytes(skb, dport_off, &in_port, sizeof(in_port), 0);
         debugf("tc ingress: first rewrited");
     } else {
         // request
-        struct pair p = {
-            .sip = iph->saddr,
-            .sport = tcph->source,
-            .dip = iph->daddr,
-            .dport = in_port,
-        };
+        struct pair p;
+        memset(&p, 0, sizeof(p));
+        set_ipv6(p.sip, src_ip);
+        set_ipv6(p.dip, dst_ip);
+        p.sport = tcph->source;
+        p.dport = in_port;
         struct origin_info *origin =
             bpf_map_lookup_elem(&pair_original_dst, &p);
         if (!origin) {
             // not exists
             // char srcip[16];
-            // ipstr(iph->saddr, srcip);
+            // ipstr(src_ip, srcip);
             // char dip[16];
-            // ipstr(iph->daddr, dip);
+            // ipstr(dst_ip, dip);
             // debugf("request origin not found %s -> %s", srcip, dip);
             // debugf("request origin not found port %d -> %d",
             //        bpf_htons(tcph->source), bpf_htons(tcph->dest));
@@ -150,9 +178,8 @@ __section("classifier_ingress") int mb_tc_ingress(struct __sk_buff *skb)
             return TC_ACT_OK;
         }
         __u16 dst_port = tcph->dest;
-        bpf_l4_csum_replace(skb, TCP_CSUM_OFF, dst_port, in_port,
-                            sizeof(dst_port));
-        bpf_skb_store_bytes(skb, TCP_DPORT_OFF, &in_port, sizeof(in_port), 0);
+        bpf_l4_csum_replace(skb, csum_off, dst_port, in_port, sizeof(dst_port));
+        bpf_skb_store_bytes(skb, dport_off, &in_port, sizeof(in_port), 0);
         debugf("tc ingress: rewrited");
     }
     return TC_ACT_OK;
@@ -166,27 +193,62 @@ __section("classifier_egress") int mb_tc_egress(struct __sk_buff *skb)
     if ((void *)(eth + 1) > data_end) {
         return TC_ACT_SHOT;
     }
-    if (bpf_htons(eth->h_proto) != ETH_P_IP) {
-        return TC_ACT_OK;
-    }
 
-    struct iphdr *iph = (struct iphdr *)(eth + 1);
-    if ((void *)(iph + 1) > data_end) {
-        return TC_ACT_SHOT;
-    }
+    __u32 src_ip[4];
+    __u32 dst_ip[4];
+    struct tcphdr *tcph;
+    __u32 csum_off;
+    __u32 sport_off;
 
-    if (iph->protocol == IPPROTO_IPIP) {
-        iph = ((void *)iph + iph->ihl * 4);
+    switch (bpf_htons(eth->h_proto)) {
+#if ENABLE_IPV4
+    case ETH_P_IP: {
+        struct iphdr *iph = (struct iphdr *)(eth + 1);
         if ((void *)(iph + 1) > data_end) {
+            return TC_ACT_SHOT;
+        }
+        if (iph->protocol == IPPROTO_IPIP) {
+            iph = ((void *)iph + iph->ihl * 4);
+            if ((void *)(iph + 1) > data_end) {
+                return TC_ACT_OK;
+            }
+        }
+        if (iph->protocol != IPPROTO_TCP) {
             return TC_ACT_OK;
         }
+        set_ipv4(src_ip, iph->saddr);
+        set_ipv4(dst_ip, iph->daddr);
+        tcph = (struct tcphdr *)(iph + 1);
+        csum_off =
+            ETH_HLEN + sizeof(struct iphdr) + offsetof(struct tcphdr, check);
+        sport_off =
+            ETH_HLEN + sizeof(struct iphdr) + offsetof(struct tcphdr, source);
+        break;
     }
-
-    if (iph->protocol != IPPROTO_TCP) {
+#endif
+#if ENABLE_IPV6
+    case ETH_P_IPV6: {
+        struct ipv6hdr *iph = (struct ipv6hdr *)(eth + 1);
+        if ((void *)(iph + 1) > data_end) {
+            return TC_ACT_SHOT;
+        }
+        if (iph->nexthdr != IPPROTO_TCP) {
+            return TC_ACT_OK;
+        }
+        set_ipv6(src_ip, iph->saddr.in6_u.u6_addr32);
+        set_ipv6(dst_ip, iph->daddr.in6_u.u6_addr32);
+        tcph = (struct tcphdr *)(iph + 1);
+        csum_off =
+            ETH_HLEN + sizeof(struct ipv6hdr) + offsetof(struct tcphdr, check);
+        sport_off =
+            ETH_HLEN + sizeof(struct ipv6hdr) + offsetof(struct tcphdr, source);
+        break;
+    }
+#endif
+    default:
         return TC_ACT_OK;
     }
 
-    struct tcphdr *tcph = (struct tcphdr *)(iph + 1);
     if ((void *)(tcph + 1) > data_end) {
         return TC_ACT_SHOT;
     }
@@ -199,12 +261,12 @@ __section("classifier_egress") int mb_tc_egress(struct __sk_buff *skb)
     // like from 172.31.0.123:15006 => 10.0.0.1:23456
     // to avoid the client drop packet, we must reset the source port from
     // 15006 to 80.
-    struct pair p = {
-        .dip = iph->saddr,
-        .dport = tcph->source,
-        .sip = iph->daddr,
-        .sport = tcph->dest,
-    };
+    struct pair p;
+    memset(&p, 0, sizeof(p));
+    set_ipv6(p.dip, src_ip);
+    set_ipv6(p.sip, dst_ip);
+    p.dport = tcph->source;
+    p.sport = tcph->dest;
     struct origin_info *origin = bpf_map_lookup_elem(&pair_original_dst, &p);
     if (!origin) {
         // not exists
@@ -222,8 +284,8 @@ __section("classifier_egress") int mb_tc_egress(struct __sk_buff *skb)
         bpf_map_delete_elem(&pair_original_dst, &p);
     }
     __u16 src_port = origin->port;
-    bpf_l4_csum_replace(skb, TCP_CSUM_OFF, in_port, src_port, sizeof(src_port));
-    bpf_skb_store_bytes(skb, TCP_SPORT_OFF, &src_port, sizeof(src_port), 0);
+    bpf_l4_csum_replace(skb, csum_off, in_port, src_port, sizeof(src_port));
+    bpf_skb_store_bytes(skb, sport_off, &src_port, sizeof(src_port), 0);
     debugf("tc egress: rewrited");
     return TC_ACT_OK;
 }

--- a/config/vars.go
+++ b/config/vars.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package config
 
+import (
+	"os"
+)
+
 const (
 	ModeIstio   = "istio"
 	ModeLinkerd = "linkerd"
@@ -29,6 +33,8 @@ var (
 	UseReconnect = true
 	Debug        = false
 	EnableCNI    = false
+	EnableIPV4   = getEnvOrDefault("ENABLE_IPV4", "true") == "true"
+	EnableIPV6   = getEnvOrDefault("ENABLE_IPV6", "false") == "true"
 	IsKind       = false // is Kubernetes running in Docker
 	HostProc     string
 	CNIBinDir    string
@@ -37,3 +43,10 @@ var (
 	KubeConfig   string
 	Context      string
 )
+
+func getEnvOrDefault(name, defaultValue string) string {
+	if value, ok := os.LookupEnv(name); ok {
+		return value
+	}
+	return defaultValue
+}

--- a/internal/cni-server/cni-plugin.go
+++ b/internal/cni-server/cni-plugin.go
@@ -154,8 +154,14 @@ func (s *server) buildListener(netns string) error {
 	if len(addrs) != 1 {
 		log.Warnf("get ip address for %s: res: %v, merbridge only support single ip address", netns, addrs)
 	}
+
 	lc := s.listenConfig(addrs[0], netns)
-	l, err := lc.Listen(context.Background(), "tcp", "0.0.0.0:39807")
+	var l net.Listener
+	if config.EnableIPV4 {
+		l, err = lc.Listen(context.Background(), "tcp", "0.0.0.0:39807")
+	} else {
+		l, err = lc.Listen(context.Background(), "tcp", "[::]:39807")
+	}
 	if err != nil {
 		return err
 	}

--- a/pkg/linux/ip.go
+++ b/pkg/linux/ip.go
@@ -22,10 +22,16 @@ import (
 	"unsafe"
 )
 
-func IP2Linux(ipstr string) (uint32, error) {
+func IP2Linux(ipstr string) (unsafe.Pointer, error) {
 	ip := net.ParseIP(ipstr)
 	if ip == nil {
-		return 0, fmt.Errorf("error parse ip: %s", ipstr)
+		return nil, fmt.Errorf("error parse ip: %s", ipstr)
 	}
-	return *(*uint32)(unsafe.Pointer(&ip[12])), nil
+	if ip.To4() != nil {
+		// ipv4, we need to clear the bytes
+		for i := 0; i < 12; i++ {
+			ip[i] = 0
+		}
+	}
+	return unsafe.Pointer(&ip[0]), nil
 }

--- a/pkg/linux/ip_test.go
+++ b/pkg/linux/ip_test.go
@@ -18,6 +18,7 @@ package linux
 
 import (
 	"testing"
+	"unsafe"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -49,8 +50,8 @@ func TestIP2Linux(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
+				assert.Equal(t, c.want, *(*uint32)(unsafe.Add(ip, 12)))
 			}
-			assert.Equal(t, c.want, ip)
 		})
 	}
 }


### PR DESCRIPTION
To enable ipv6 only, just add the following env in the daemon set:
```yaml
env:
  - name: ENABLE_IPV4
    value: "false"
  - name: ENABLE_IPV6
    value: "true"
```
Note that ipv6 requires cni-mode enabled