### PR TITLE
- ignore host mounted cgroup path and limit output

### DIFF
--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -47,7 +47,7 @@ ifeq ($(USE_RECONNECT),1)
     MACROS:= $(MACROS) -DUSE_RECONNECT
 endif
 
-CGROUP2_PATH ?= $(shell mount | grep cgroup2 | awk '{print $$3}')
+CGROUP2_PATH ?= $(shell mount | grep cgroup2 | awk '{print $$3}' | grep -v "^/host" | head -n 1)
 ifeq ($(CGROUP2_PATH),)
 $(error It looks like your system does not have cgroupv2 enabled, or the automatic recognition fails. Please enable cgroupv2, or specify the path of cgroupv2 manually via CGROUP2_PATH parameter.)
 endif


### PR DESCRIPTION
Fix https://github.com/merbridge/merbridge/issues/144