### PR TITLE
> fix panic if get netns error

### DIFF
--- a/internal/cni-server/cni-plugin.go
+++ b/internal/cni-server/cni-plugin.go
@@ -267,9 +267,10 @@ func (s *server) checkAndRepairPodPrograms() error {
 	for _, f := range hostProc {
 		if _, err = strconv.Atoi(f.Name()); err == nil {
 			pid := f.Name()
-			netns, err := ns.GetNS(fmt.Sprintf("%s/%s/ns/net", config.HostProc, pid))
+			np := fmt.Sprintf("%s/%s/ns/net", config.HostProc, pid)
+			netns, err := ns.GetNS(np)
 			if err != nil {
-				log.Errorf("Failed to get ns for %s", netns.Path())
+				log.Errorf("Failed to get ns for %s, error: %v", np, err)
 				continue
 			}
 			if skipListening(pid) {


### PR DESCRIPTION
Error: 
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x3b60e16]

goroutine 1 [running]:
github.com/merbridge/merbridge/internal/cni-server.(*server).checkAndRepairPodPrograms(0xc000648630)
	/app/internal/cni-server/cni-plugin.go:272 +0x176
github.com/merbridge/merbridge/internal/cni-server.(*server).Start(0xc000648630)
	/app/internal/cni-server/server.go:68 +0x125
github.com/merbridge/merbridge/app/cmd.glob..func1(0x6451000, {0x44756d7?, 0x6?, 0x6?})
	/app/app/cmd/root.go:50 +0x138
github.com/spf13/cobra.(*Command).execute(0x6451000, {0xc000070080, 0x6, 0x6})
	/go/pkg/mod/github.com/spf13/cobra@v1.4.0/command.go:856 +0x67c
github.com/spf13/cobra.(*Command).ExecuteC(0x6451000)
	/go/pkg/mod/github.com/spf13/cobra@v1.4.0/command.go:974 +0x3b4
github.com/spf13/cobra.(*Command).Execute(...)
	/go/pkg/mod/github.com/spf13/cobra@v1.4.0/command.go:902
github.com/merbridge/merbridge/app/cmd.Execute()
	/app/app/cmd/root.go:68 +0x25
main.main()
	/app/app/main.go:21 +0x17
```