### PR TITLE
Fix exclude-inbound-ports

### DIFF
--- a/controller/localip/localip.go
+++ b/controller/localip/localip.go
@@ -185,7 +185,7 @@ func parsePodConfigFromAnnotations(annotations map[string]string, pod *podConfig
 		}
 	}
 	pod.statusPort = uint16(statusPort)
-	excludeInboundPorts := []uint16{15090, 15006, 15001, 15000} // todo changeme
+	excludeInboundPorts := []uint16{15090, 15006, 15001, 15000, 15020} // todo changeme
 	if v, ok := annotations["traffic.sidecar.istio.io/excludeInboundPorts"]; ok {
 		excludeInboundPorts = append(excludeInboundPorts, getPortsFromString(v)...)
 	}

--- a/controller/localip/localip_test.go
+++ b/controller/localip/localip_test.go
@@ -33,7 +33,7 @@ func Test_parseConfig(t *testing.T) {
 			expect: &podConfig{
 				statusPort: 15021,
 				excludeInPorts: [MaxItemLen]uint16{
-					15090, 15006, 15001, 15000,
+					15090, 15006, 15001, 15000, 15020,
 				},
 			},
 		},
@@ -45,7 +45,7 @@ func Test_parseConfig(t *testing.T) {
 			expect: &podConfig{
 				statusPort: 15021,
 				excludeInPorts: [MaxItemLen]uint16{
-					15090, 15006, 15001, 15000,
+					15090, 15006, 15001, 15000, 15020,
 					12345,
 					80,
 				},
@@ -59,7 +59,7 @@ func Test_parseConfig(t *testing.T) {
 			expect: &podConfig{
 				statusPort: 15021,
 				excludeInPorts: [MaxItemLen]uint16{
-					15090, 15006, 15001, 15000,
+					15090, 15006, 15001, 15000, 15020,
 				},
 				excludeOutRanges: [MaxItemLen]cidr{
 					{
@@ -81,7 +81,7 @@ func Test_parseConfig(t *testing.T) {
 			expect: &podConfig{
 				statusPort: 15021,
 				excludeInPorts: [MaxItemLen]uint16{
-					15090, 15006, 15001, 15000,
+					15090, 15006, 15001, 15000, 15020,
 				},
 				excludeOutRanges: [MaxItemLen]cidr{
 					{
@@ -99,7 +99,7 @@ func Test_parseConfig(t *testing.T) {
 			expect: &podConfig{
 				statusPort: 15021,
 				excludeInPorts: [MaxItemLen]uint16{
-					15090, 15006, 15001, 15000,
+					15090, 15006, 15001, 15000, 15020,
 				},
 				excludeOutRanges: [MaxItemLen]cidr{
 					{


### PR DESCRIPTION
https://istio.io/latest/docs/ops/deployment/requirements/#ports-used-by-istio

Should exclude 15020 as well, otherwise probes rewrited by istio would fail