### PR TITLE
Config knob to enable/disable dns packet redirection

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -63,7 +63,7 @@ jobs:
         kubectl exec $(kubectl get po -l app=sleep -o=jsonpath='{..metadata.name}') -c sleep -- curl -s -v helloworld:5000/hello
     - name: install merbridge
       run: |
-        nohup go run -exec sudo ./app/main.go -k -m istio -d > mbctl.log &
+        nohup go run -exec sudo ./app/main.go -k -m istio -d --dns-redir=true > mbctl.log &
         while true; do [ "$(cat mbctl.log | grep 'Pod Watcher Ready')" = "" ] || break && (echo waiting for mbctl watcher ready; sleep 3); done
     - name: test connect with Merbridge
       run: |

--- a/app/cmd/root.go
+++ b/app/cmd/root.go
@@ -40,7 +40,7 @@ var rootCmd = &cobra.Command{
 	Short: "Use eBPF to speed up your Service Mesh like crossing an Einstein-Rosen Bridge.",
 	Long:  `Use eBPF to speed up your Service Mesh like crossing an Einstein-Rosen Bridge.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := ebpfs.LoadMBProgs(config.Mode, config.UseReconnect, config.Debug); err != nil {
+		if err := ebpfs.LoadMBProgs(config.Mode, config.UseReconnect, config.Debug, config.DNSRedirection); err != nil {
 			return fmt.Errorf("failed to load ebpf programs: %v", err)
 		}
 
@@ -97,6 +97,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&config.IsKind, "kind", "k", false, "Kubernetes in Kind mode")
 	rootCmd.PersistentFlags().StringVarP(&config.IpsFile, "ips-file", "f", "", "Current node ips file name")
 	rootCmd.PersistentFlags().BoolVar(&config.EnableCNI, "cni-mode", false, "Enable Merbridge CNI plugin")
+	rootCmd.PersistentFlags().BoolVar(&config.DNSRedirection, "dns-redir", false, "Enable DNS message redirection for Istio service mesh")
 	// If hardware checksum not enabled, we should disable tx checksum, otherwise,
 	// this can cause problems with Pods communication across hosts (Kubernetes Service logic) when CNI mode enabled.
 	// Turning this off may make network performance worse.

--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -47,6 +47,10 @@ ifeq ($(USE_RECONNECT),1)
     MACROS:= $(MACROS) -DUSE_RECONNECT
 endif
 
+ifeq ($(DNS_REDIR),1)
+    MACROS:= $(MACROS) -DDNS_REDIR
+endif
+
 CGROUP2_PATH ?= $(shell mount | grep cgroup2 | awk '{print $$3}' | grep -v "^/host" | head -n 1)
 ifeq ($(CGROUP2_PATH),)
 $(error It looks like your system does not have cgroupv2 enabled, or the automatic recognition fails. Please enable cgroupv2, or specify the path of cgroupv2 manually via CGROUP2_PATH parameter.)

--- a/bpf/mb_recvmsg.c
+++ b/bpf/mb_recvmsg.c
@@ -25,6 +25,8 @@ __section("cgroup/recvmsg4") int mb_recvmsg4(struct bpf_sock_addr *ctx)
     // only works on istio
     return 1;
 #endif
+
+#ifdef DNS_REDIR
     if (bpf_htons(ctx->user_port) != DNS_CAPTURE_PORT) {
         return 1;
     }
@@ -43,6 +45,7 @@ __section("cgroup/recvmsg4") int mb_recvmsg4(struct bpf_sock_addr *ctx)
     } else {
         printk("failed get origin");
     }
+#endif
     return 1;
 }
 

--- a/bpf/mb_sendmsg.c
+++ b/bpf/mb_sendmsg.c
@@ -25,6 +25,8 @@ __section("cgroup/sendmsg4") int mb_sendmsg4(struct bpf_sock_addr *ctx)
     // only works on istio
     return 1;
 #endif
+
+#ifdef DNS_REDIR
     if (bpf_htons(ctx->user_port) != 53) {
         return 1;
     }
@@ -48,6 +50,7 @@ __section("cgroup/sendmsg4") int mb_sendmsg4(struct bpf_sock_addr *ctx)
         ctx->user_port = bpf_htons(DNS_CAPTURE_PORT);
         ctx->user_ip4 = 0x100007f;
     }
+#endif
     return 1;
 }
 

--- a/config/vars.go
+++ b/config/vars.go
@@ -26,6 +26,7 @@ var (
 	Mode             string
 	IpsFile          string
 	UseReconnect     = true
+	DNSRedirection   = false
 	Debug            = false
 	EnableCNI        = false
 	HardwareCheckSum = false

--- a/deploy/all-in-one-linkerd.yaml
+++ b/deploy/all-in-one-linkerd.yaml
@@ -72,6 +72,7 @@ spec:
         - /host/ips/ips.txt
         - --use-reconnect=false
         - --cni-mode=false
+        - --dns-redir=false
         lifecycle:
           preStop:
             exec:

--- a/deploy/all-in-one.yaml
+++ b/deploy/all-in-one.yaml
@@ -72,6 +72,7 @@ spec:
         - /host/ips/ips.txt
         - --use-reconnect=true
         - --cni-mode=false
+        - --dns-redir=false
         lifecycle:
           preStop:
             exec:

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -64,6 +64,7 @@ Merbridge args command
 - {{ .Values.ipsFilePath }}
 - --use-reconnect={{ if eq .Values.mode "istio" }}true{{ else }}false{{ end }}
 - --cni-mode={{ .Values.cniMode }}
+- --dns-redir={{ .Values.dnsRedir }}
 {{- if ne .Values.mountPath.proc "/host/proc" }}
 - --host-proc={{ .Values.mountPath.proc }}
 {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -8,6 +8,7 @@ namespace: istio-system
 mode: istio
 ipsFilePath: /host/ips/ips.txt
 cniMode: false
+dnsRedir: false
 
 # some settings of deployment
 image:

--- a/internal/ebpfs/prog.go
+++ b/internal/ebpfs/prog.go
@@ -21,7 +21,7 @@ import (
 	"os/exec"
 )
 
-func LoadMBProgs(meshMode string, useReconnect bool, debug bool) error {
+func LoadMBProgs(meshMode string, useReconnect bool, debug bool, dnsRedir bool) error {
 	if os.Getuid() != 0 {
 		return fmt.Errorf("root user in required for this process or container")
 	}
@@ -33,6 +33,9 @@ func LoadMBProgs(meshMode string, useReconnect bool, debug bool) error {
 	}
 	if useReconnect {
 		cmd.Env = append(cmd.Env, "USE_RECONNECT=1")
+	}
+	if dnsRedir {
+		cmd.Env = append(cmd.Env, "DNS_REDIR=1")
 	}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
Istio does not enable dns redirection by default.
This PR provides an option to explicitly enable/disable
DNS redirection related eBPF programs. User need to
edit the merbridge daemonset and modify `--dns-redir` to true
to enable the dns redirection. 

Signed-off-by: Anil Kumar Vishnoi <vishnoianil@gmail.com>