### PR TITLE
feat: add support for kuma service mesh

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -234,6 +234,8 @@ jobs:
       run: |
         set -e
         
+        sleep 15
+        
         service_name=$(kubectl get dataplane $(kubectl get po -l service=example-server -o=jsonpath='{..metadata.name}') -o=jsonpath='{..spec.networking.inbound[0].tags.kuma\.io/service}')
         echo "service name: $service_name"
         kubectl exec $(kubectl get po -l service=example-client -o=jsonpath='{..metadata.name}') -c curl -- curl -s -v "$service_name".mesh

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -152,12 +152,8 @@ jobs:
         metadata:
           name: example-server
           labels:
-            app: example-server
+            service: example-server
         spec:
-          strategy:
-            rollingUpdate:
-              maxSurge: 1
-              maxUnavailable: 0
           selector:
             matchLabels:
               service: example-server
@@ -192,7 +188,7 @@ jobs:
         metadata:
           name: example-client
           labels:
-            app: example-client
+            service: example-client
         spec:
           strategy:
             rollingUpdate:
@@ -220,7 +216,7 @@ jobs:
       run: |
         sleep 5
         service_name=$(kubectl get dataplane $(kubectl get po -l service=example-server -o=jsonpath='{..metadata.name}') -o=jsonpath='{..spec.networking.inbound[0].tags.kuma\.io/service}')
-        kubectl exec $(kubectl get po -l service=example-client -o=jsonpath='{..metadata.name}') -c curl -- curl -s -v --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 0 --retry-max-time 40 "$service_name".mesh
+        kubectl exec $(kubectl get po -l service=example-client -o=jsonpath='{..metadata.name}') -c curl -- curl -s -v "$service_name".mesh
     - name: disable kuma-init containers using container-patch
       run: |
         kubectl patch deployment example-server --patch '{"spec": {"template": {"metadata": {"annotations": {"kuma.io/container-patches": "disable-init-container"}}}}}'
@@ -236,9 +232,9 @@ jobs:
         
         kubectl get all -A
         
-        sleep 15
+        echo "\n\n###\n\n"
         
-        kubectl get all -A
+        kubectl logs deploy/example-server
         
         service_name=$(kubectl get dataplane $(kubectl get po -l service=example-server -o=jsonpath='{..metadata.name}') -o=jsonpath='{..spec.networking.inbound[0].tags.kuma\.io/service}')
         echo "service name: $service_name"

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -214,7 +214,7 @@ jobs:
     - name: test connect without Merbridge
       run: |
         service_name=$(kubectl get dataplane $(kubectl get po -l service=example-server -o=jsonpath='{..metadata.name}') -o=jsonpath='{..spec.networking.inbound[0].tags.kuma\.io/service}')
-        kubectl exec $(kubectl get po -l service=example-client -o=jsonpath='{..metadata.name}') -c curl -- bash -c "curl -s -v $service_name".mesh"
+        kubectl exec $(kubectl get po -l service=example-client -o=jsonpath='{..metadata.name}') -c curl -- curl -s -v $service_name".mesh
     - name: disable kuma-init containers using container-patch
       run: |
         kubectl patch deployment example-server --patch '{"spec": {"template": {"metadata": {"annotations": {"kuma.io/container-patches": "disable-init-container", "kuma.io/virtual-probes": "disabled"}}}}}'

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -215,6 +215,7 @@ jobs:
         kubectl rollout status deployment example-client
     - name: test connect without Merbridge
       run: |
+        sleep 5
         service_name=$(kubectl get dataplane $(kubectl get po -l service=example-server -o=jsonpath='{..metadata.name}') -o=jsonpath='{..spec.networking.inbound[0].tags.kuma\.io/service}')
         kubectl exec $(kubectl get po -l service=example-client -o=jsonpath='{..metadata.name}') -c curl -- curl -s -v --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 0 --retry-max-time 40 "$service_name".mesh
     - name: disable kuma-init containers using container-patch

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -214,14 +214,12 @@ jobs:
         kubectl rollout status deployment example-client
     - name: test connect without Merbridge
       run: |
-        sleep 5
         service_name=$(kubectl get dataplane $(kubectl get po -l service=example-server -o=jsonpath='{..metadata.name}') -o=jsonpath='{..spec.networking.inbound[0].tags.kuma\.io/service}')
         kubectl exec $(kubectl get po -l service=example-client -o=jsonpath='{..metadata.name}') -c curl -- curl -s -v "$service_name".mesh
     - name: disable kuma-init containers using container-patch
       run: |
-        kubectl patch deployment example-server --patch '{"spec": {"template": {"metadata": {"annotations": {"kuma.io/container-patches": "disable-init-container"}}}}}'
+        kubectl patch deployment example-server --patch '{"spec": {"template": {"metadata": {"annotations": {"kuma.io/container-patches": "disable-init-container", "kuma.io/virtual-probes": "disabled"}}}}}'
         kubectl patch deployment example-client --patch '{"spec": {"template": {"metadata": {"annotations": {"kuma.io/container-patches": "disable-init-container"}}}}}'
-        # kubectl delete pod --all --wait=true
     - name: install merbridge
       run: |
         nohup go run -exec sudo ./app/main.go -k -m kuma -d > mbctl.log &
@@ -230,14 +228,7 @@ jobs:
       run: |
         set -e
         
-        kubectl get all -A
-        
-        echo "\n\n###\n\n"
-        
-        kubectl logs deploy/example-server
-        
         service_name=$(kubectl get dataplane $(kubectl get po -l service=example-server -o=jsonpath='{..metadata.name}') -o=jsonpath='{..spec.networking.inbound[0].tags.kuma\.io/service}')
-        echo "service name: $service_name"
         kubectl exec $(kubectl get po -l service=example-client -o=jsonpath='{..metadata.name}') -c curl -- curl -s -v "$service_name".mesh
         sudo cat /sys/kernel/debug/tracing/trace > /tmp/trace-log
         

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -224,7 +224,9 @@ jobs:
     - name: disable kuma-init containers using container-patch
       run: |
         kubectl patch deployment example-server --patch '{"spec": {"template": {"metadata": {"annotations": {"kuma.io/container-patches": "disable-init-container"}}}}}'
+        kubectl rollout status deployment example-server
         kubectl patch deployment example-client --patch '{"spec": {"template": {"metadata": {"annotations": {"kuma.io/container-patches": "disable-init-container"}}}}}'
+        kubectl rollout status deployment example-client
         kubectl delete pod --all
         kubectl rollout status deployment example-server
         kubectl rollout status deployment example-client

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -204,7 +204,7 @@ jobs:
     - name: test connect without Merbridge
       run: |
         service_name=$(kubectl get dataplane $(kubectl get po -l service=example-server -o=jsonpath='{..metadata.name}') -o=jsonpath='{..spec.networking.inbound[0].tags.kuma\.io/service}')
-        kubectl exec $(kubectl get po -l service=example-client -o=jsonpath='{..metadata.name}') -c curl -- curl -s -v "$service_name".mesh
+        kubectl exec $(kubectl get po -l service=example-client -o=jsonpath='{..metadata.name}') -c curl -- curl -s -v --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 0 --retry-max-time 40 "$service_name".mesh
     - name: disable kuma-init containers using container-patch
       run: |
         kubectl patch deployment example-server --patch '{"spec": {"template": {"metadata": {"annotations": {"kuma.io/container-patches": "disable-init-container"}}}}}'
@@ -219,7 +219,7 @@ jobs:
     - name: test connect with Merbridge
       run: |
         service_name=$(kubectl get dataplane $(kubectl get po -l service=example-server -o=jsonpath='{..metadata.name}') -o=jsonpath='{..spec.networking.inbound[0].tags.kuma\.io/service}')
-        kubectl exec $(kubectl get po -l service=example-client -o=jsonpath='{..metadata.name}') -c curl -- curl -s -v "$service_name".mesh
+        kubectl exec $(kubectl get po -l service=example-client -o=jsonpath='{..metadata.name}') -c curl -- curl -s -v --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 0 --retry-max-time 40 "$service_name".mesh
         sudo cat /sys/kernel/debug/tracing/trace > /tmp/trace-log
         
         # check if eBPF works

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -214,7 +214,15 @@ jobs:
         kubectl rollout status deployment example-client
     - name: test connect without Merbridge
       run: |
-        sleep 5
+        kubectl get pods
+        printf "\n\n###\n\n
+        kubectl describe deploy example-server
+        printf "\n\n###\n\n
+        kubectl logs deploy/example-server
+        printf "\n\n###\n\n
+        kubectl describe deploy example-client
+        printf "\n\n###\n\n
+        kubectl logs deploy/example-client
         service_name=$(kubectl get dataplane $(kubectl get po -l service=example-server -o=jsonpath='{..metadata.name}') -o=jsonpath='{..spec.networking.inbound[0].tags.kuma\.io/service}')
         kubectl exec $(kubectl get po -l service=example-client -o=jsonpath='{..metadata.name}') -c curl -- curl -s -v "$service_name".mesh
     - name: disable kuma-init containers using container-patch

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -224,12 +224,8 @@ jobs:
     - name: disable kuma-init containers using container-patch
       run: |
         kubectl patch deployment example-server --patch '{"spec": {"template": {"metadata": {"annotations": {"kuma.io/container-patches": "disable-init-container"}}}}}'
-        kubectl rollout status deployment example-server
         kubectl patch deployment example-client --patch '{"spec": {"template": {"metadata": {"annotations": {"kuma.io/container-patches": "disable-init-container"}}}}}'
-        kubectl rollout status deployment example-client
-        kubectl delete pod --all
-        kubectl rollout status deployment example-server
-        kubectl rollout status deployment example-client
+        kubectl delete pod --all --wait=true
     - name: install merbridge
       run: |
         nohup go run -exec sudo ./app/main.go -k -m kuma -d > mbctl.log &

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -214,15 +214,20 @@ jobs:
         kubectl rollout status deployment example-client
     - name: test connect without Merbridge
       run: |
+        printf "### pods\n\n\n"
         kubectl get pods
-        printf "\n\n###\n\n"
+        printf "\n\n### described example-server \n\n\n"
         kubectl describe deploy example-server
-        printf "\n\n###\n\n"
-        kubectl logs deploy/example-server
-        printf "\n\n###\n\n"
+        printf "\n\n### logs example-server/nginx\n\n\n"
+        kubectl logs deploy/example-server -c nginx
+        printf "\n\n### logs example-server/kuma-sidecar\n\n\n"
+        kubectl logs deploy/example-server -c kuma-sidecar
+        printf "\n\n### described example-client\n\n\n"
         kubectl describe deploy example-client
-        printf "\n\n###\n\n"
-        kubectl logs deploy/example-client
+        printf "\n\n### logs example-client/curl\n\n\n"
+        kubectl logs deploy/example-client -c curl
+        printf "\n\n### logs example-client/kuma-sidecar\n\n\n"
+        kubectl logs deploy/example-client -c kuma-sidecar
         service_name=$(kubectl get dataplane $(kubectl get po -l service=example-server -o=jsonpath='{..metadata.name}') -o=jsonpath='{..spec.networking.inbound[0].tags.kuma\.io/service}')
         kubectl exec $(kubectl get po -l service=example-client -o=jsonpath='{..metadata.name}') -c curl -- curl -s -v "$service_name".mesh
     - name: disable kuma-init containers using container-patch

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -214,7 +214,7 @@ jobs:
     - name: test connect without Merbridge
       run: |
         service_name=$(kubectl get dataplane $(kubectl get po -l service=example-server -o=jsonpath='{..metadata.name}') -o=jsonpath='{..spec.networking.inbound[0].tags.kuma\.io/service}')
-        kubectl exec $(kubectl get po -l service=example-client -o=jsonpath='{..metadata.name}') -c curl -- curl -s -v $service_name".mesh
+        kubectl exec $(kubectl get po -l service=example-client -o=jsonpath='{..metadata.name}') -c curl -- curl -s -v "$service_name".mesh
     - name: disable kuma-init containers using container-patch
       run: |
         kubectl patch deployment example-server --patch '{"spec": {"template": {"metadata": {"annotations": {"kuma.io/container-patches": "disable-init-container", "kuma.io/virtual-probes": "disabled"}}}}}'

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -154,6 +154,10 @@ jobs:
           labels:
             app: example-server
         spec:
+          strategy:
+            rollingUpdate:
+              maxSurge: 1
+              maxUnavailable: 0
           selector:
             matchLabels:
               service: example-server
@@ -190,6 +194,10 @@ jobs:
           labels:
             app: example-client
         spec:
+          strategy:
+            rollingUpdate:
+              maxSurge: 1
+              maxUnavailable: 0
           selector:
             matchLabels:
               service: example-client

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -235,7 +235,8 @@ jobs:
         set -e
         
         service_name=$(kubectl get dataplane $(kubectl get po -l service=example-server -o=jsonpath='{..metadata.name}') -o=jsonpath='{..spec.networking.inbound[0].tags.kuma\.io/service}')
-        kubectl exec $(kubectl get po -l service=example-client -o=jsonpath='{..metadata.name}') -c curl -- curl -s -v --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 0 --retry-max-time 40 "$service_name".mesh
+        echo "service name: $service_name"
+        kubectl exec $(kubectl get po -l service=example-client -o=jsonpath='{..metadata.name}') -c curl -- curl -s -v "$service_name".mesh
         sudo cat /sys/kernel/debug/tracing/trace > /tmp/trace-log
         
         # check if eBPF works

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -225,7 +225,7 @@ jobs:
       run: |
         kubectl patch deployment example-server --patch '{"spec": {"template": {"metadata": {"annotations": {"kuma.io/container-patches": "disable-init-container"}}}}}'
         kubectl patch deployment example-client --patch '{"spec": {"template": {"metadata": {"annotations": {"kuma.io/container-patches": "disable-init-container"}}}}}'
-        kubectl delete pod --all --wait=true
+        # kubectl delete pod --all --wait=true
     - name: install merbridge
       run: |
         nohup go run -exec sudo ./app/main.go -k -m kuma -d > mbctl.log &
@@ -234,7 +234,11 @@ jobs:
       run: |
         set -e
         
+        kubectl get all -A
+        
         sleep 15
+        
+        kubectl get all -A
         
         service_name=$(kubectl get dataplane $(kubectl get po -l service=example-server -o=jsonpath='{..metadata.name}') -o=jsonpath='{..spec.networking.inbound[0].tags.kuma\.io/service}')
         echo "service name: $service_name"

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -145,7 +145,6 @@ jobs:
             name: http
             appProtocol: http
           selector:
-            app: example-app
             service: example-server
         ---
         apiVersion: apps/v1
@@ -157,12 +156,10 @@ jobs:
         spec:
           selector:
             matchLabels:
-              app: example-app
               service: example-server
           template:
             metadata:
               labels:
-                app: example-app
                 service: example-server
             spec:
               terminationGracePeriodSeconds: 0
@@ -195,12 +192,10 @@ jobs:
         spec:
           selector:
             matchLabels:
-              app: example-app
               service: example-client
           template:
             metadata:
               labels:
-                app: example-app
                 service: example-client
             spec:
               terminationGracePeriodSeconds: 0

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -170,7 +170,17 @@ jobs:
                 image: "nginx:stable"
                 imagePullPolicy: IfNotPresent
                 ports:
-                - containerPort: 80' | kubectl apply -f -
+                - containerPort: 80
+                readinessProbe:
+                  httpGet:
+                    path: /
+                    port: 80
+                  initialDelaySeconds: 3
+                  periodSeconds: 3
+                livenessProbe:
+                  httpGet:
+                    path: /
+                    port: 80' | kubectl apply -f -
         
         # client
         

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -107,33 +107,11 @@ jobs:
     - name: install kuma
       run: |
         ./scripts/install-kuma.sh
-    - name: apply container patch which disables kuma-init container
-      run: |
-        # this step is just temporary, till kuma won't support disabling kuma-init
-        # containers as a part of configuration
-        
-        cat > /tmp/container-patch.yaml <<EOF
-        apiVersion: kuma.io/v1alpha1
-        kind: ContainerPatch
-        metadata:
-          name: disable-init-container
-          namespace: kuma-system
-        spec:
-          initPatch:
-          - op: replace
-            path: /command
-            value: '["echo"]'
-        EOF
-        
-        kubectl apply -f /tmp/container-patch.yaml
-        rm -f /tmp/container-patch.yaml
     - name: annotate default namespace to automatically inject kuma to pods it contains
       run: |
         kubectl label ns default kuma.io/sidecar-injection=enabled
-    - name: deploy test apps
+    - name: deploy test server app
       run: |
-        # server
-        
         echo '---
         apiVersion: v1
         kind: Service
@@ -180,8 +158,10 @@ jobs:
                     path: /
                     port: 80' | kubectl apply -f -
         
-        # client
-        
+        # wait till our example deployment is ready
+        kubectl rollout status deployment example-server
+    - name: deploy test client app
+      run: |
         echo '---
         apiVersion: apps/v1
         kind: Deployment
@@ -209,27 +189,32 @@ jobs:
                 command: ["/bin/sleep", "infinity"]
                 imagePullPolicy: IfNotPresent' | kubectl apply -f -
         
-        # wait till our example deployment are fully ready
-        kubectl rollout status deployment example-server
+        # wait till our example deployment is ready
         kubectl rollout status deployment example-client
+    - name: apply container patch which disables kuma-init container
+      run: |
+        # this step is just temporary, till kuma won't support disabling kuma-init
+        # containers as a part of configuration
+        
+        cat > /tmp/container-patch.yaml <<EOF
+        apiVersion: kuma.io/v1alpha1
+        kind: ContainerPatch
+        metadata:
+          name: disable-init-container
+          namespace: kuma-system
+        spec:
+          initPatch:
+          - op: replace
+            path: /command
+            value: '["echo"]'
+        EOF
+        
+        kubectl apply -f /tmp/container-patch.yaml
+        rm -f /tmp/container-patch.yaml
     - name: test connect without Merbridge
       run: |
-        printf "### pods\n\n\n"
-        kubectl get pods
-        printf "\n\n### described example-server \n\n\n"
-        kubectl describe deploy example-server
-        printf "\n\n### logs example-server/nginx\n\n\n"
-        kubectl logs deploy/example-server -c nginx
-        printf "\n\n### logs example-server/kuma-sidecar\n\n\n"
-        kubectl logs deploy/example-server -c kuma-sidecar
-        printf "\n\n### described example-client\n\n\n"
-        kubectl describe deploy example-client
-        printf "\n\n### logs example-client/curl\n\n\n"
-        kubectl logs deploy/example-client -c curl
-        printf "\n\n### logs example-client/kuma-sidecar\n\n\n"
-        kubectl logs deploy/example-client -c kuma-sidecar
         service_name=$(kubectl get dataplane $(kubectl get po -l service=example-server -o=jsonpath='{..metadata.name}') -o=jsonpath='{..spec.networking.inbound[0].tags.kuma\.io/service}')
-        kubectl exec $(kubectl get po -l service=example-client -o=jsonpath='{..metadata.name}') -c curl -- curl -s -v "$service_name".mesh
+        kubectl exec $(kubectl get po -l service=example-client -o=jsonpath='{..metadata.name}') -c curl -- bash -c "curl -s -v $service_name".mesh"
     - name: disable kuma-init containers using container-patch
       run: |
         kubectl patch deployment example-server --patch '{"spec": {"template": {"metadata": {"annotations": {"kuma.io/container-patches": "disable-init-container", "kuma.io/virtual-probes": "disabled"}}}}}'

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -214,6 +214,7 @@ jobs:
         kubectl rollout status deployment example-client
     - name: test connect without Merbridge
       run: |
+        sleep 5
         service_name=$(kubectl get dataplane $(kubectl get po -l service=example-server -o=jsonpath='{..metadata.name}') -o=jsonpath='{..spec.networking.inbound[0].tags.kuma\.io/service}')
         kubectl exec $(kubectl get po -l service=example-client -o=jsonpath='{..metadata.name}') -c curl -- curl -s -v "$service_name".mesh
     - name: disable kuma-init containers using container-patch

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -232,6 +232,8 @@ jobs:
         while true; do [ "$(cat mbctl.log | grep 'Pod Watcher Ready')" = "" ] || break && (echo waiting for mbctl watcher ready; sleep 3); done
     - name: test connect with Merbridge
       run: |
+        set -e
+        
         service_name=$(kubectl get dataplane $(kubectl get po -l service=example-server -o=jsonpath='{..metadata.name}') -o=jsonpath='{..spec.networking.inbound[0].tags.kuma\.io/service}')
         kubectl exec $(kubectl get po -l service=example-client -o=jsonpath='{..metadata.name}') -c curl -- curl -s -v --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 0 --retry-max-time 40 "$service_name".mesh
         sudo cat /sys/kernel/debug/tracing/trace > /tmp/trace-log

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -165,6 +165,7 @@ jobs:
                 app: example-app
                 service: example-server
             spec:
+              terminationGracePeriodSeconds: 0
               containers:
               - name: nginx
                 image: "nginx:stable"
@@ -202,6 +203,7 @@ jobs:
                 app: example-app
                 service: example-client
             spec:
+              terminationGracePeriodSeconds: 0
               containers:
               - name: curl
                 image: curlimages/curl

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -75,3 +75,155 @@ jobs:
         [ "$(sudo cat /tmp/trace-log | grep 'bytes with eBPF successfully')" = "" ] && (echo eBPF redirect progs not work; sudo cat /tmp/trace-log; sudo bpftool prog; sudo bpftool map; cat mbctl.log; sudo ps -ef; exit 12)
         [ "$(sudo cat /tmp/trace-log | grep 'successfully deal DNS redirect query')" = "" ] && (echo DNS Proxy not work; sudo cat /tmp/trace-log; sudo bpftool prog; sudo bpftool map; cat mbctl.log; sudo ps -ef; exit 13)
         sudo rm -f /tmp/trace-log
+
+  # kuma
+
+  kuma-e2e:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 30
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'needs-e2e-test') }}
+    env:
+      KUMA_VERSION: '1.7.0'
+      KIND_VERSION: v0.11.1
+      KERNEL_VERSION: v5.4
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.18
+    - name: install bpftool
+      run: |
+        sudo bash ./scripts/build-bpftool.sh
+    - name: setup kind cluster
+      run: |
+        ./scripts/setup-kind.sh
+    - name: try load and unload
+      run: |
+        uname -a
+        make load
+        make attach
+        make clean
+    - name: install kuma
+      run: |
+        ./scripts/install-kuma.sh
+    - name: apply container patch which disables kuma-init container
+      run: |
+        # this step is just temporary, till kuma won't support disabling kuma-init
+        # containers as a part of configuration
+        
+        cat > /tmp/container-patch.yaml <<EOF
+        apiVersion: kuma.io/v1alpha1
+        kind: ContainerPatch
+        metadata:
+          name: disable-init-container
+          namespace: kuma-system
+        spec:
+          initPatch:
+          - op: replace
+            path: /command
+            value: '["echo"]'
+        EOF
+        
+        kubectl apply -f /tmp/container-patch.yaml
+        rm -f /tmp/container-patch.yaml
+    - name: annotate default namespace to automatically inject kuma to pods it contains
+      run: |
+        kubectl label ns default kuma.io/sidecar-injection=enabled
+    - name: deploy test apps
+      run: |
+        # server
+        
+        echo '---
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: example-server
+        spec:
+          ports:
+          - port: 80
+            name: http
+            appProtocol: http
+          selector:
+            app: example-app
+            service: example-server
+        ---
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: example-server
+          labels:
+            app: example-server
+        spec:
+          selector:
+            matchLabels:
+              app: example-app
+              service: example-server
+          template:
+            metadata:
+              labels:
+                app: example-app
+                service: example-server
+            spec:
+              containers:
+              - name: nginx
+                image: "nginx:stable"
+                imagePullPolicy: IfNotPresent
+                ports:
+                - containerPort: 80' | kubectl apply -f -
+        
+        # client
+        
+        echo '---
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: example-client
+          labels:
+            app: example-client
+        spec:
+          selector:
+            matchLabels:
+              app: example-app
+              service: example-client
+          template:
+            metadata:
+              labels:
+                app: example-app
+                service: example-client
+            spec:
+              containers:
+              - name: curl
+                image: curlimages/curl
+                command: ["/bin/sleep", "infinity"]
+                imagePullPolicy: IfNotPresent' | kubectl apply -f -
+        
+        # wait till our example deployment are fully ready
+        kubectl rollout status deployment example-server
+        kubectl rollout status deployment example-client
+    - name: test connect without Merbridge
+      run: |
+        service_name=$(kubectl get dataplane $(kubectl get po -l service=example-server -o=jsonpath='{..metadata.name}') -o=jsonpath='{..spec.networking.inbound[0].tags.kuma\.io/service}')
+        kubectl exec $(kubectl get po -l service=example-client -o=jsonpath='{..metadata.name}') -c curl -- curl -s -v "$service_name".mesh
+    - name: disable kuma-init containers using container-patch
+      run: |
+        kubectl patch deployment example-server --patch '{"spec": {"template": {"metadata": {"annotations": {"kuma.io/container-patches": "disable-init-container"}}}}}'
+        kubectl patch deployment example-client --patch '{"spec": {"template": {"metadata": {"annotations": {"kuma.io/container-patches": "disable-init-container"}}}}}'
+        kubectl delete pod --all
+        kubectl rollout status deployment example-server
+        kubectl rollout status deployment example-client
+    - name: install merbridge
+      run: |
+        nohup go run -exec sudo ./app/main.go -k -m kuma -d > mbctl.log &
+        while true; do [ "$(cat mbctl.log | grep 'Pod Watcher Ready')" = "" ] || break && (echo waiting for mbctl watcher ready; sleep 3); done
+    - name: test connect with Merbridge
+      run: |
+        service_name=$(kubectl get dataplane $(kubectl get po -l service=example-server -o=jsonpath='{..metadata.name}') -o=jsonpath='{..spec.networking.inbound[0].tags.kuma\.io/service}')
+        kubectl exec $(kubectl get po -l service=example-client -o=jsonpath='{..metadata.name}') -c curl -- curl -s -v "$service_name".mesh
+        sudo cat /sys/kernel/debug/tracing/trace > /tmp/trace-log
+        
+        # check if eBPF works
+        [ "$(sudo cat /tmp/trace-log | grep 'from user container')" = "" ] && (echo eBPF progs not work; sudo cat /tmp/trace-log; sudo bpftool prog; sudo bpftool map; cat mbctl.log; sudo ps -ef; exit 11)
+        [ "$(sudo cat /tmp/trace-log | grep 'bytes with eBPF successfully')" = "" ] && (echo eBPF redirect progs not work; sudo cat /tmp/trace-log; sudo bpftool prog; sudo bpftool map; cat mbctl.log; sudo ps -ef; exit 12)
+        [ "$(sudo cat /tmp/trace-log | grep 'successfully deal DNS redirect query')" = "" ] && (echo DNS Proxy not work; sudo cat /tmp/trace-log; sudo bpftool prog; sudo bpftool map; cat mbctl.log; sudo ps -ef; exit 13)
+        sudo rm -f /tmp/trace-log

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -215,13 +215,13 @@ jobs:
     - name: test connect without Merbridge
       run: |
         kubectl get pods
-        printf "\n\n###\n\n
+        printf "\n\n###\n\n"
         kubectl describe deploy example-server
-        printf "\n\n###\n\n
+        printf "\n\n###\n\n"
         kubectl logs deploy/example-server
-        printf "\n\n###\n\n
+        printf "\n\n###\n\n"
         kubectl describe deploy example-client
-        printf "\n\n###\n\n
+        printf "\n\n###\n\n"
         kubectl logs deploy/example-client
         service_name=$(kubectl get dataplane $(kubectl get po -l service=example-server -o=jsonpath='{..metadata.name}') -o=jsonpath='{..spec.networking.inbound[0].tags.kuma\.io/service}')
         kubectl exec $(kubectl get po -l service=example-client -o=jsonpath='{..metadata.name}') -c curl -- curl -s -v "$service_name".mesh

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,8 @@ lint: lint-c lint-go
 
 format: format-c format-go
 
-# update generated yaml for merbridge on linkerd and istio deploy templates
-helm: helm-linkerd helm-istio
+# update generated yaml for merbridge on linkerd, istio and kuma deploy templates
+helm: helm-linkerd helm-istio helm-kuma
 
 # generate merbridge on linkerd deploy templates
 helm-linkerd:
@@ -38,6 +38,10 @@ helm-linkerd:
 # generate merbridge on istio deploy templates
 helm-istio:
 	helm template -n "istio-system" merbridge helm > deploy/all-in-one.yaml
+
+# generate merbridge on kuma deploy templates
+helm-kuma:
+	helm template --set-string "mode=kuma" -n "kuma-system" merbridge helm > deploy/all-in-one-kuma.yaml
 
 # package helm release
 helm-package:
@@ -69,3 +73,13 @@ helm-ci: helm-install
 	fi
 
 	@rm -rf deploy/all-in-one-linkerd-g.yaml
+
+	@echo "start to check deploy/all-in-one-kuma.yaml"
+	@helm template --set-string "mode=kuma" -n "kuma-system" merbridge helm > deploy/all-in-one-kuma-g.yaml
+	@cmp -s deploy/all-in-one-kuma.yaml deploy/all-in-one-kuma-g.yaml; \
+	RETVAL=$$?; \
+	if [ $$RETVAL -ne 0 ]; then \
+	  echo "deploy/all-in-one-kuma.yaml is incorrect, remember to run make helm-kuma to update all-in-one-kuma.yaml"; rm -rf deploy/all-in-one-kuma-g.yaml; exit 1; \
+	fi
+
+	@rm -rf deploy/all-in-one-kuma-g.yaml

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ Or on Linkerd cluster:
 kubectl apply -f https://raw.githubusercontent.com/merbridge/merbridge/main/deploy/all-in-one-linkerd.yaml
 ```
 
+Or on Kuma cluster:
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/merbridge/merbridge/main/deploy/all-in-one-kuma.yaml
+```
+
 > Note: currently only works on Linux kernel >= 5.7, run `uname -r` check your kernel version before install merbridge.
 
 If you want to install Merbridge by `Helm`, read the guidelines: [Deploy Merbridge with Helm](deploy/).
@@ -32,6 +38,11 @@ kubectl delete -f https://raw.githubusercontent.com/merbridge/merbridge/main/dep
 - Linkerd:
 ```bash
 kubectl delete -f https://raw.githubusercontent.com/merbridge/merbridge/main/deploy/all-in-one-linkerd.yaml
+```
+
+- Kuma:
+```bash
+kubectl delete -f https://raw.githubusercontent.com/merbridge/merbridge/main/deploy/all-in-one-kuma.yaml
 ```
 
 ## Get involved

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,6 +3,7 @@
 ## eBPF enhancement
 - [ ] Metrics
 - [X] Linkerd2 Supported
+- [X] Kuma Support
 - [ ] Cross-node mode(XDP?)
 - [ ] IPv6 Support
 - [X] DNS Redirect

--- a/app/cmd/options/options.go
+++ b/app/cmd/options/options.go
@@ -28,8 +28,10 @@ func NewOptions() error {
 	if config.Debug {
 		log.SetLevel(log.DebugLevel)
 	}
-	if config.Mode != config.ModeIstio && config.Mode != config.ModeLinkerd {
-		return fmt.Errorf("invalid mode %q, current only support istio and linkerd", config.Mode)
+	switch config.Mode {
+	case config.ModeIstio, config.ModeLinkerd, config.ModeKuma:
+		return nil
+	default:
+		return fmt.Errorf("invalid mode %q, current only support istio, linkerd and kuma", config.Mode)
 	}
-	return nil
 }

--- a/app/cmd/root.go
+++ b/app/cmd/root.go
@@ -91,7 +91,7 @@ func init() {
 	log.SetReportCaller(true)
 
 	// Get some flags from commands
-	rootCmd.PersistentFlags().StringVarP(&config.Mode, "mode", "m", config.ModeIstio, "Service mesh mode, current support istio and linkerd")
+	rootCmd.PersistentFlags().StringVarP(&config.Mode, "mode", "m", config.ModeIstio, "Service mesh mode, current support istio, linkerd and kuma")
 	rootCmd.PersistentFlags().BoolVarP(&config.UseReconnect, "use-reconnect", "r", true, "Use re-connect mode as same-node acceleration")
 	rootCmd.PersistentFlags().BoolVarP(&config.Debug, "debug", "d", false, "Debug mode")
 	rootCmd.PersistentFlags().BoolVarP(&config.IsKind, "kind", "k", false, "Kubernetes in Kind mode")

--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -13,6 +13,8 @@ ifeq ($(MESH_MODE),istio)
     MACROS:= $(MACROS) -DMESH=1
 else ifeq ($(MESH_MODE),linkerd)
     MACROS:= $(MACROS) -DMESH=2
+else ifeq ($(MESH_MODE),kuma)
+    MACROS:= $(MACROS) -DMESH=3
 else
 $(error MESH_MODE $(MESH_MODE) isn't supported)
 endif

--- a/bpf/headers/mesh.h
+++ b/bpf/headers/mesh.h
@@ -18,6 +18,7 @@ limitations under the License.
 
 #define ISTIO 1
 #define LINKERD 2
+#define KUMA 3
 
 #ifndef MESH
 #define MESH 1
@@ -57,6 +58,24 @@ limitations under the License.
 
 #ifndef DNS_CAPTURE_PORT
 #define DNS_CAPTURE_PORT 0 // todo fix me
+#endif
+
+#elif MESH == KUMA
+
+#ifndef OUT_REDIRECT_PORT
+#define OUT_REDIRECT_PORT 15001
+#endif
+
+#ifndef IN_REDIRECT_PORT
+#define IN_REDIRECT_PORT 15006
+#endif
+
+#ifndef SIDECAR_USER_ID
+#define SIDECAR_USER_ID 5678
+#endif
+
+#ifndef DNS_CAPTURE_PORT
+#define DNS_CAPTURE_PORT 15053
 #endif
 
 #else

--- a/bpf/mb_connect.c
+++ b/bpf/mb_connect.c
@@ -24,8 +24,8 @@ static __u32 outip = 1;
 static inline int udp4_connect(struct bpf_sock_addr *ctx)
 {
 
-#if MESH != ISTIO
-    // only works on istio
+#if MESH != ISTIO && MESH != KUMA
+    // only works on istio and kuma
     return 1;
 #endif
     if (!(is_port_listen_current_ns(ctx, 0, OUT_REDIRECT_PORT) &&
@@ -56,7 +56,7 @@ static inline int tcp4_connect(struct bpf_sock_addr *ctx)
     // todo(kebe7jun) more reliable way to verify,
     if (!is_port_listen_current_ns(ctx, 0, OUT_REDIRECT_PORT)) {
         // bypass normal traffic.
-        // we only deal pod's traffic managed by istio.
+        // we only deal pod's traffic managed by istio or kuma.
         return 1;
     }
     __u32 curr_pod_ip = 0;

--- a/bpf/mb_recvmsg.c
+++ b/bpf/mb_recvmsg.c
@@ -21,8 +21,8 @@ limitations under the License.
 
 __section("cgroup/recvmsg4") int mb_recvmsg4(struct bpf_sock_addr *ctx)
 {
-#if MESH != ISTIO
-    // only works on istio
+#if MESH != ISTIO && MESH != KUMA
+    // only works on istio and kuma
     return 1;
 #endif
     if (bpf_htons(ctx->user_port) != DNS_CAPTURE_PORT) {

--- a/bpf/mb_sendmsg.c
+++ b/bpf/mb_sendmsg.c
@@ -21,8 +21,8 @@ limitations under the License.
 
 __section("cgroup/sendmsg4") int mb_sendmsg4(struct bpf_sock_addr *ctx)
 {
-#if MESH != ISTIO
-    // only works on istio
+#if MESH != ISTIO && MESH != KUMA
+    // only works on istio and kuma
     return 1;
 #endif
     if (bpf_htons(ctx->user_port) != 53) {

--- a/config/vars.go
+++ b/config/vars.go
@@ -18,6 +18,7 @@ package config
 const (
 	ModeIstio   = "istio"
 	ModeLinkerd = "linkerd"
+	ModeKuma    = "kuma"
 	LocalPodIps = "/sys/fs/bpf/tc/globals/local_pod_ips"
 )
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -43,6 +43,15 @@ The Merbridge [v0.4.0] has been installed in namespace [istio-system]. It will b
 helm install -n linkerd --set mode=linkerd merbridge helm
 ```
 
+### Install Merbridge on Kuma
+
++ set mode=kuma to switch to kuma mode
++ set namespace where merbridge is going to install by -n .
+
+``` bash
+helm install -n kuma-system --set mode=kuma merbridge helm
+```
+
 ### Uninstall
 
 + excute this command in the namespace where merbridge has been installed
@@ -65,6 +74,8 @@ make helm
 make helm-istio
 # update linkerd deploy yaml
 make helm-linkerd
+# update kuma deploy yaml
+make helm-kuma
 # package helm charts
 make helm-package
 ```

--- a/deploy/all-in-one-kuma.yaml
+++ b/deploy/all-in-one-kuma.yaml
@@ -1,0 +1,155 @@
+---
+# Source: merbridge/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: merbridge
+  namespace: kuma-system
+  labels:
+    app: merbridge
+---
+# Source: merbridge/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: merbridge
+  labels:
+    app: merbridge
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - get
+  - watch
+---
+# Source: merbridge/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: merbridge
+  labels:
+    app: merbridge
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: merbridge
+subjects:
+- kind: ServiceAccount
+  name: merbridge
+  namespace: kuma-system
+---
+# Source: merbridge/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: merbridge
+  namespace: kuma-system
+  labels:
+    app: merbridge
+spec:
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: merbridge
+  template:
+    metadata:
+      labels:
+        app: merbridge
+    spec:
+      hostNetwork: true
+      containers:
+      - image: "ghcr.io/merbridge/merbridge:latest"
+        imagePullPolicy: Always
+        name: merbridge
+        args:
+        - /app/mbctl
+        - -m
+        - kuma
+        - --ips-file
+        - /host/ips/ips.txt
+        - --use-reconnect=true
+        - --cni-mode=false
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - make
+              - -k
+              - clean
+        resources:
+          requests:
+            cpu: 100m
+            memory: 200Mi
+          limits:
+            cpu: 300m
+            memory: 200Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+          - mountPath: /sys/fs/cgroup
+            name: sys-fs-cgroup
+          - mountPath: /host/ips
+            name: host-ips
+          - mountPath: /host/opt/cni/bin
+            name: cni-bin-dir
+          - mountPath: /host/etc/cni/net.d
+            name: cni-config-dir
+          - mountPath: /host/proc
+            name: host-proc
+          - mountPath: /host/var/run
+            name: host-var-run
+            mountPropagation: Bidirectional
+      initContainers:
+      - image: "ghcr.io/merbridge/merbridge:latest"
+        imagePullPolicy: Always
+        name: init
+        args:
+        - sh
+        - -c
+        - nsenter --net=/host/proc/1/ns/net ip -o addr | awk '{print $4}' | tee /host/ips/ips.txt
+        resources:
+          requests:
+            cpu: 100m
+            memory: 50Mi
+          limits:
+            cpu: 300m
+            memory: 50Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+          - mountPath: /host/ips
+            name: host-ips
+          - mountPath: /host/proc
+            name: host-proc
+      dnsPolicy: ClusterFirst
+      nodeSelector:
+        kubernetes.io/os: linux
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      serviceAccount: merbridge
+      serviceAccountName: merbridge
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - operator: Exists
+      volumes:
+      - hostPath:
+          path: /sys/fs/cgroup
+        name: sys-fs-cgroup
+      - hostPath:
+          path: /proc
+        name: host-proc
+      - emptyDir: {}
+        name: host-ips
+      - hostPath:
+          path: /opt/cni/bin
+        name: cni-bin-dir
+      - hostPath:
+          path: /etc/cni/net.d
+        name: cni-config-dir
+      - hostPath:
+          path: /var/run
+        name: host-var-run

--- a/deploy/all-in-one-linkerd.yaml
+++ b/deploy/all-in-one-linkerd.yaml
@@ -79,7 +79,7 @@ spec:
               - make
               - -k
               - clean
-        resources: 
+        resources:
           requests:
             cpu: 100m
             memory: 200Mi

--- a/deploy/all-in-one.yaml
+++ b/deploy/all-in-one.yaml
@@ -79,7 +79,7 @@ spec:
               - make
               - -k
               - clean
-        resources: 
+        resources:
           requests:
             cpu: 100m
             memory: 200Mi

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,13 +2,14 @@ apiVersion: v2
 name: merbridge
 description: Use eBPF to speed up your Service Mesh like crossing an Einstein-Rosen Bridge.
 type: application
-version: v0.4.0
-appVersion: v0.4.0
+version: v0.5.0
+appVersion: v0.5.0
 maintainers:
   - name: Merbridge Maintainers
     url: https://github.com/merbridge/merbridge
 keywords:
 - istio
+- kuma
 - ebpf
 sources:
   - https://github.com/merbridge/merbridge

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -62,7 +62,7 @@ Merbridge args command
 - {{ .Values.mode }}
 - --ips-file
 - {{ .Values.ipsFilePath }}
-- --use-reconnect={{ if eq .Values.mode "istio" }}true{{ else }}false{{ end }}
+- --use-reconnect={{ if or (eq .Values.mode "istio") (eq .Values.mode "kuma") }}true{{ else }}false{{ end }}
 - --cni-mode={{ .Values.cniMode }}
 {{- if ne .Values.mountPath.proc "/host/proc" }}
 - --host-proc={{ .Values.mountPath.proc }}

--- a/helm/templates/daemonset.yaml
+++ b/helm/templates/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
             exec:
               command:
               {{- include "merbridge.cmd.clean" . | nindent 14 }}
-        resources: 
+        resources:
           requests:
             cpu: {{ .Values.resources.container.request.cpu }}
             memory: {{ .Values.resources.container.request.memory }}

--- a/internal/pods/util.go
+++ b/internal/pods/util.go
@@ -34,3 +34,12 @@ func IsLinkerdInjectedSidecar(pod *v1.Pod) bool {
 	}
 	return false
 }
+
+func IsKumaInjectedSidecar(pod *v1.Pod) bool {
+	for _, c := range pod.Spec.Containers {
+		if c.Name == "kuma-sidecar" && len(pod.Spec.Containers) != 1 {
+			return true
+		}
+	}
+	return false
+}

--- a/scripts/install-kuma.sh
+++ b/scripts/install-kuma.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Copyright © 2022 Merbridge Authors
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+KUMA_VERSION=${KUMA_VERSION:-1.7.0}
+if [ -z "$SKIP_INSTALL" ]; then
+    tmp=$(mktemp -d)
+    pushd "${tmp}"
+    VERSION=$KUMA_VERSION curl -L https://kuma.io/installer.sh | bash -
+    sudo cp -rf "kuma-${KUMA_VERSION}/bin/kumactl" /usr/local/bin
+    popd
+    rm -rf "${tmp}"
+fi
+
+kumactl install control-plane | kubectl apply -f -
+kubectl rollout status deployment -n kuma-system kuma-control-plane


### PR DESCRIPTION
- Updated make files to build helm chart and k8s deployment
  manifest with Kuma support
- Bumped helm chart to 0.5.0
- Kuma supports DNS redirection like Istio does, so I updated
  ebpf files which so far were only used for Istio, to also
  be compiled for Kuma
- As Kuma also supports dynamic reload, I updated hack/reload-prog.sh
  to be able to use it with Kuma
   - shebang has to be in the first line of the script, so I moved
     it there
   - as the shell code is definitelly written with bash in mind
     (i.e. usage of arrays), I changed shebang from `sh` to `bash`
- Updated all README.md files with kuma-related instructions and
  informations
- Added `scripts/install-kuma.sh` script which can be used
  to install kuma and wait till the deployment will be ready
- Modified github actions workflow to include e2e test for kuma

Signed-off-by: Bart Smykla <bartek@smykla.com>