### PR TITLE
chore: few small stylistic improvements and fixes

### DIFF
--- a/app/cmd/options/options.go
+++ b/app/cmd/options/options.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package options
 
 import (

--- a/app/cmd/root.go
+++ b/app/cmd/root.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package cmd
 
 import (
@@ -54,7 +55,7 @@ var rootCmd = &cobra.Command{
 			installCNI(cmd.Context(), cniReady)
 		}
 
-		// todo wait for stop
+		// todo: wait for stop
 		if err := controller.Run(cniReady); err != nil {
 			log.Fatal(err)
 			return err
@@ -63,7 +64,7 @@ var rootCmd = &cobra.Command{
 	},
 }
 
-// Execute excute root command and its child commands
+// Execute executes root command and its child commands
 func Execute() {
 	err := rootCmd.Execute()
 	if err != nil {
@@ -92,10 +93,10 @@ func init() {
 
 	// Get some flags from commands
 	rootCmd.PersistentFlags().StringVarP(&config.Mode, "mode", "m", config.ModeIstio, "Service mesh mode, current support istio, linkerd and kuma")
-	rootCmd.PersistentFlags().BoolVarP(&config.UseReconnect, "use-reconnect", "r", true, "Use re-connect mode as same-node acceleration")
+	rootCmd.PersistentFlags().BoolVarP(&config.UseReconnect, "use-reconnect", "r", true, "Use re-connect mode for same-node acceleration")
 	rootCmd.PersistentFlags().BoolVarP(&config.Debug, "debug", "d", false, "Debug mode")
-	rootCmd.PersistentFlags().BoolVarP(&config.IsKind, "kind", "k", false, "Kubernetes in Kind mode")
-	rootCmd.PersistentFlags().StringVarP(&config.IpsFile, "ips-file", "f", "", "Current node ips file name")
+	rootCmd.PersistentFlags().BoolVarP(&config.IsKind, "kind", "k", false, "Enable when Kubernetes is running in Kind")
+	rootCmd.PersistentFlags().StringVarP(&config.IpsFile, "ips-file", "f", "", "Current node IPs filename")
 	rootCmd.PersistentFlags().BoolVar(&config.EnableCNI, "cni-mode", false, "Enable Merbridge CNI plugin")
 	rootCmd.PersistentFlags().StringVar(&config.HostProc, "host-proc", "/host/proc", "/proc mount path")
 	rootCmd.PersistentFlags().StringVar(&config.CNIBinDir, "cni-bin-dir", "/host/opt/cni/bin", "/opt/cni/bin mount path")

--- a/app/cni/main.go
+++ b/app/cni/main.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package main
 
 import (

--- a/app/main.go
+++ b/app/main.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package main
 
 import "github.com/merbridge/merbridge/app/cmd"

--- a/config/vars.go
+++ b/config/vars.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package config
 
 const (
@@ -29,7 +30,7 @@ var (
 	UseReconnect  = true
 	Debug         = false
 	EnableCNI     = false
-	IsKind        = false // is Run Kubernetes in Docker
+	IsKind        = false // is Kubernetes running in Docker
 	HostProc      string
 	CNIBinDir     string
 	CNIConfigDir  string

--- a/controller/localip/localip.go
+++ b/controller/localip/localip.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package localip
 
 import (
@@ -71,13 +72,13 @@ func RunLocalIPController(client kubernetes.Interface, cniReady chan struct{}) e
 }
 
 func createLocalIPController(client kubernetes.Interface) pods.Watcher {
-	locaName, err := os.Hostname()
+	localName, err := os.Hostname()
 	if err != nil {
 		panic(err)
 	}
 	return pods.Watcher{
 		Client:          client,
-		CurrentNodeName: locaName,
+		CurrentNodeName: localName,
 		OnAddFunc:       addFunc,
 		OnUpdateFunc:    updateFunc,
 		OnDeleteFunc:    deleteFunc,

--- a/controller/localip/localip_test.go
+++ b/controller/localip/localip_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package localip
 
 import (

--- a/controller/start.go
+++ b/controller/start.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (
@@ -21,7 +22,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/merbridge/merbridge/app/cmd/options"
-	localip "github.com/merbridge/merbridge/controller/localip"
+	"github.com/merbridge/merbridge/controller/localip"
 	"github.com/merbridge/merbridge/pkg/kube"
 )
 
@@ -43,7 +44,7 @@ func Run(cniReady chan struct{}) error {
 		return fmt.Errorf("create client error: %v", err)
 	}
 
-	// Run local ip controller
+	// run local ip controller
 	if err = localip.RunLocalIPController(client, cniReady); err != nil {
 		return fmt.Errorf("run local ip controller error: %v", err)
 	}

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -9,6 +9,7 @@ maintainers:
     url: https://github.com/merbridge/merbridge
 keywords:
 - istio
+- linkerd
 - kuma
 - ebpf
 sources:

--- a/internal/cni-server/cni-plugin.go
+++ b/internal/cni-server/cni-plugin.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package cniserver
 
 import (
@@ -49,7 +50,7 @@ type qdisc struct {
 }
 
 func getMarkKeyOfNetns(netns string) uint32 {
-	// todo check confict?
+	// todo check conflict?
 	algorithm := fnv.New32a()
 	_, _ = algorithm.Write([]byte(netns))
 	return algorithm.Sum32()
@@ -118,7 +119,7 @@ func (s *server) CmdDelete(args *skel.CmdArgs) (err error) {
 
 // listen on 39807
 func (s *server) buildListener(netns string) error {
-	addrs := []net.Addr{}
+	var addrs []net.Addr
 	ifaces, _ := net.Interfaces()
 	for _, iface := range ifaces {
 		if iface.Name == "lo" {
@@ -176,7 +177,7 @@ func (s *server) listenConfig(addr net.Addr, netns string) net.ListenConfig {
 					operr = err
 					return
 				}
-				var key uint32 = getMarkKeyOfNetns(netns)
+				key := getMarkKeyOfNetns(netns)
 				operr = m.Update(key, ip, ebpf.UpdateAny)
 				if operr != nil {
 					return
@@ -205,7 +206,7 @@ func (s *server) checkAndRepairPodPrograms() error {
 				continue
 			}
 			if skipListening(pid) {
-				// ignore uninjected pods
+				// ignore non-injected pods
 				log.Debugf("skip listening for pid(%s)", pid)
 				continue
 			}

--- a/internal/cni-server/handlers.go
+++ b/internal/cni-server/handlers.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package cniserver
 
 import (

--- a/internal/cni-server/install.go
+++ b/internal/cni-server/install.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package cniserver
 
 import (

--- a/internal/cni-server/server.go
+++ b/internal/cni-server/server.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package cniserver
 
 import (
@@ -43,7 +44,7 @@ type server struct {
 	unixSockPath string
 	bpfMountPath string
 	// qdiscs is for cleaning up all tc programs when merbridge exits
-	// key: netns, value: qidsc info
+	// key: netns, value: qdisc info
 	qdiscs map[string]qdisc
 	stop   chan struct{}
 }

--- a/internal/ebpfs/map.go
+++ b/internal/ebpfs/map.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package ebpfs
 
 import (

--- a/internal/ebpfs/prog.go
+++ b/internal/ebpfs/prog.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package ebpfs
 
 import (

--- a/internal/pods/util.go
+++ b/internal/pods/util.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package pods
 
 import v1 "k8s.io/api/core/v1"

--- a/internal/pods/watcher.go
+++ b/internal/pods/watcher.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package pods
 
 import (

--- a/pkg/cniplugin/kube.go
+++ b/pkg/cniplugin/kube.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package cniplugin
 
 import (

--- a/pkg/cniplugin/plugin.go
+++ b/pkg/cniplugin/plugin.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package cniplugin
 
 import (
@@ -166,7 +167,7 @@ func CmdAdd(args *skel.CmdArgs) (err error) {
 	return types.PrintResult(result, conf.CNIVersion)
 }
 
-func CmdCheck(args *skel.CmdArgs) (err error) {
+func CmdCheck(*skel.CmdArgs) (err error) {
 	return err
 }
 

--- a/pkg/cniplugin/plugin_test.go
+++ b/pkg/cniplugin/plugin_test.go
@@ -34,7 +34,7 @@ func TestIgnorePod(t *testing.T) {
 		want bool
 	}{
 		{
-			name: "uninjected pod",
+			name: "non-injected pod",
 			args: args{
 				pod: &plugin.PodInfo{
 					Containers: []string{"foo", "bar"},

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package kube
 
 import (
@@ -34,7 +35,7 @@ func GetK8sConfigConfigWithFile(kubeconfig, context string) *rest.Config {
 	if kubeconfig != "" {
 		info, err := os.Stat(kubeconfig)
 		if err != nil || info.Size() == 0 {
-			// If the specified kubeconfig doesn't exists / empty file / any other error
+			// If the specified kubeconfig doesn't exist / empty file / any other error
 			// from file stat, fall back to default
 			kubeconfig = ""
 		}

--- a/pkg/linux/ip.go
+++ b/pkg/linux/ip.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package linux
 
 import (
@@ -49,11 +50,9 @@ func IsCurrentNodeIP(ipstr string, ipListFile string) bool {
 		}
 	}
 	log.Debugf("no ips file found, fetch ips from interfaces")
-	ifaces, _ := net.Interfaces()
-	// handle err
+	ifaces, _ := net.Interfaces() // todo: handle err
 	for _, i := range ifaces {
-		addrs, _ := i.Addrs()
-		// handle err
+		addrs, _ := i.Addrs() // todo: handle err
 		for _, addr := range addrs {
 			switch v := addr.(type) {
 			case *net.IPNet:
@@ -65,7 +64,7 @@ func IsCurrentNodeIP(ipstr string, ipListFile string) bool {
 					return true
 				}
 			}
-			// process IP address
+			// todo: process IP address
 		}
 	}
 	return false

--- a/pkg/linux/ip_test.go
+++ b/pkg/linux/ip_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package linux
 
 import (


### PR DESCRIPTION
- Added `linkerd` to keywords in helm's Chart.yaml file
- Added empty line under copyright comments in `*.go` files where
  it was missing which makes my IDE (goland) as well as
  it's consistent with some other files, where this empty line
  was present
- Fixed typos:
  - `exist` -> `exists` in `pkg/kube/client.go`
  - `confict` -> `conflict` in `internal/cni-server/cni-plugin.go`
  - `uninjected` -> `non-injected`
  in `internal/cni-server/cni-plugin.go` and
  `pkg/cniplugin/plugin_test.go`
  - `locaName` -> `localName` in `controller/localip/localip.go`
  - `excute` -> `execute` in `app/cmd/root.go`
  - `qidsc` -> `qdisc` in `internal/cni-server/server.go`
- Changed empty slice declaration `addrs := []net.Addr{}` ->
  `var addrs []net.Addr` in `internal/cni-server/cni-plugin.go`
- Changed one full declaration to the shorthand one:
  `var key uint32 = getMarkKeyOfNetns(netns)` ->
  `key := getMarkKeyOfNetns(netns)`
  in `internal/cni-server/cni-plugin.go`
- Added missing `todo` keywords in comments
  in `internal/cni-server/cni-plugin.go`
- Removed unnecessary (unused) parameter name in `CmdCheck`
  function in `pkg/cniplugin/plugin.go`
- Added missing `:` character after `todo` keyword
  in `app/cmd/root.go`
- Few stylistic changes in CLI flags descriptions
  in `app/cmd/root.go`
- Lowered case in the first word of one of the comments
  in `controller/start.go` to make it consistent with other
  comments
- Changed comment of `IsKind` variable in `config/vars.go`

Signed-off-by: Bart Smykla <bartek@smykla.com>