### PR TITLE
Avoid using goroutines to keep listeners

### DIFF
--- a/internal/cni-server/server.go
+++ b/internal/cni-server/server.go
@@ -44,9 +44,12 @@ type server struct {
 	unixSockPath string
 	bpfMountPath string
 	// qdiscs is for cleaning up all tc programs when merbridge exits
-	// key: netns, value: qdisc info
-	qdiscs map[string]qdisc
-	stop   chan struct{}
+	// key: netns(inode), value: qdisc info
+	qdiscs map[uint64]qdisc
+	// listeners are the dummy sockets created for eBPF programs to fetch the current pod ip
+	// key: netns(inode), value: net.Listener
+	listeners map[uint64]net.Listener
+	stop      chan struct{}
 }
 
 // NewServer returns a new CNI Server.
@@ -61,7 +64,8 @@ func NewServer(unixSockPath string, bpfMountPath string) Server {
 	return &server{
 		unixSockPath: unixSockPath,
 		bpfMountPath: bpfMountPath,
-		qdiscs:       make(map[string]qdisc),
+		qdiscs:       make(map[uint64]qdisc),
+		listeners:    make(map[uint64]net.Listener),
 	}
 }
 

--- a/pkg/linux/file.go
+++ b/pkg/linux/file.go
@@ -1,0 +1,34 @@
+/*
+Copyright © 2022 Merbridge Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package linux
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+func GetFileInode(path string) (uint64, error) {
+	f, err := os.Stat(path)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get the inode of %s", path)
+	}
+	stat, ok := f.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, fmt.Errorf("not syscall.Stat_t")
+	}
+	return stat.Ino, nil
+}


### PR DESCRIPTION
We don't have to create goroutines to keep listeners, instead we can just keep the listeners in memory(prevent them from being GCed), which should be cheaper than n(pods) goroutines

Besides we should use inode to identify network namespaces, because `/proc/{pid}/ns/net` and `/var/run/netns/***` have different paths but share the same inode