### PR TITLE
use host name to filter pods

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: golangci-lint
         if: github.event_name == 'pull_request'
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: v1.29

--- a/app/cmd/root.go
+++ b/app/cmd/root.go
@@ -97,6 +97,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&config.Debug, "debug", "d", false, "Debug mode")
 	rootCmd.PersistentFlags().BoolVarP(&config.IsKind, "kind", "k", false, "Enable when Kubernetes is running in Kind")
 	rootCmd.PersistentFlags().StringVarP(&config.IpsFile, "ips-file", "f", "", "Current node IPs filename")
+	_ = rootCmd.PersistentFlags().MarkDeprecated("ips-file", "no need to collect node IPs")
 	rootCmd.PersistentFlags().BoolVar(&config.EnableCNI, "cni-mode", false, "Enable Merbridge CNI plugin")
 	rootCmd.PersistentFlags().StringVar(&config.HostProc, "host-proc", "/host/proc", "/proc mount path")
 	rootCmd.PersistentFlags().StringVar(&config.CNIBinDir, "cni-bin-dir", "/host/opt/cni/bin", "/opt/cni/bin mount path")

--- a/config/vars.go
+++ b/config/vars.go
@@ -24,15 +24,14 @@ const (
 )
 
 var (
-	CurrentNodeIP string
-	Mode          string
-	IpsFile       string
-	UseReconnect  = true
-	Debug         = false
-	EnableCNI     = false
-	IsKind        = false // is Kubernetes running in Docker
-	HostProc      string
-	CNIBinDir     string
-	CNIConfigDir  string
-	HostVarRun    string
+	Mode         string
+	IpsFile      string // not used
+	UseReconnect = true
+	Debug        = false
+	EnableCNI    = false
+	IsKind       = false // is Kubernetes running in Docker
+	HostProc     string
+	CNIBinDir    string
+	CNIConfigDir string
+	HostVarRun   string
 )

--- a/deploy/all-in-one-kuma.yaml
+++ b/deploy/all-in-one-kuma.yaml
@@ -91,8 +91,6 @@ spec:
         volumeMounts:
           - mountPath: /sys/fs/cgroup
             name: sys-fs-cgroup
-          - mountPath: /host/ips
-            name: host-ips
           - mountPath: /host/opt/cni/bin
             name: cni-bin-dir
           - mountPath: /host/etc/cni/net.d
@@ -102,28 +100,6 @@ spec:
           - mountPath: /host/var/run
             name: host-var-run
             mountPropagation: Bidirectional
-      initContainers:
-      - image: "ghcr.io/merbridge/merbridge:latest"
-        imagePullPolicy: Always
-        name: init
-        args:
-        - sh
-        - -c
-        - nsenter --net=/host/proc/1/ns/net ip -o addr | awk '{print $4}' | tee /host/ips/ips.txt
-        resources:
-          requests:
-            cpu: 100m
-            memory: 50Mi
-          limits:
-            cpu: 300m
-            memory: 50Mi
-        securityContext:
-          privileged: true
-        volumeMounts:
-          - mountPath: /host/ips
-            name: host-ips
-          - mountPath: /host/proc
-            name: host-proc
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
@@ -142,8 +118,6 @@ spec:
       - hostPath:
           path: /proc
         name: host-proc
-      - emptyDir: {}
-        name: host-ips
       - hostPath:
           path: /opt/cni/bin
         name: cni-bin-dir

--- a/deploy/all-in-one-kuma.yaml
+++ b/deploy/all-in-one-kuma.yaml
@@ -68,8 +68,6 @@ spec:
         - /app/mbctl
         - -m
         - kuma
-        - --ips-file
-        - /host/ips/ips.txt
         - --use-reconnect=true
         - --cni-mode=false
         lifecycle:

--- a/deploy/all-in-one-linkerd.yaml
+++ b/deploy/all-in-one-linkerd.yaml
@@ -91,8 +91,6 @@ spec:
         volumeMounts:
           - mountPath: /sys/fs/cgroup
             name: sys-fs-cgroup
-          - mountPath: /host/ips
-            name: host-ips
           - mountPath: /host/opt/cni/bin
             name: cni-bin-dir
           - mountPath: /host/etc/cni/net.d
@@ -102,28 +100,6 @@ spec:
           - mountPath: /host/var/run
             name: host-var-run
             mountPropagation: Bidirectional
-      initContainers:
-      - image: "ghcr.io/merbridge/merbridge:latest"
-        imagePullPolicy: Always
-        name: init
-        args:
-        - sh
-        - -c
-        - nsenter --net=/host/proc/1/ns/net ip -o addr | awk '{print $4}' | tee /host/ips/ips.txt
-        resources:
-          requests:
-            cpu: 100m
-            memory: 50Mi
-          limits:
-            cpu: 300m
-            memory: 50Mi
-        securityContext:
-          privileged: true
-        volumeMounts:
-          - mountPath: /host/ips
-            name: host-ips
-          - mountPath: /host/proc
-            name: host-proc
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
@@ -142,8 +118,6 @@ spec:
       - hostPath:
           path: /proc
         name: host-proc
-      - emptyDir: {}
-        name: host-ips
       - hostPath:
           path: /opt/cni/bin
         name: cni-bin-dir

--- a/deploy/all-in-one-linkerd.yaml
+++ b/deploy/all-in-one-linkerd.yaml
@@ -68,8 +68,6 @@ spec:
         - /app/mbctl
         - -m
         - linkerd
-        - --ips-file
-        - /host/ips/ips.txt
         - --use-reconnect=false
         - --cni-mode=false
         lifecycle:

--- a/deploy/all-in-one.yaml
+++ b/deploy/all-in-one.yaml
@@ -91,8 +91,6 @@ spec:
         volumeMounts:
           - mountPath: /sys/fs/cgroup
             name: sys-fs-cgroup
-          - mountPath: /host/ips
-            name: host-ips
           - mountPath: /host/opt/cni/bin
             name: cni-bin-dir
           - mountPath: /host/etc/cni/net.d
@@ -102,28 +100,6 @@ spec:
           - mountPath: /host/var/run
             name: host-var-run
             mountPropagation: Bidirectional
-      initContainers:
-      - image: "ghcr.io/merbridge/merbridge:latest"
-        imagePullPolicy: Always
-        name: init
-        args:
-        - sh
-        - -c
-        - nsenter --net=/host/proc/1/ns/net ip -o addr | awk '{print $4}' | tee /host/ips/ips.txt
-        resources:
-          requests:
-            cpu: 100m
-            memory: 50Mi
-          limits:
-            cpu: 300m
-            memory: 50Mi
-        securityContext:
-          privileged: true
-        volumeMounts:
-          - mountPath: /host/ips
-            name: host-ips
-          - mountPath: /host/proc
-            name: host-proc
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
@@ -142,8 +118,6 @@ spec:
       - hostPath:
           path: /proc
         name: host-proc
-      - emptyDir: {}
-        name: host-ips
       - hostPath:
           path: /opt/cni/bin
         name: cni-bin-dir

--- a/deploy/all-in-one.yaml
+++ b/deploy/all-in-one.yaml
@@ -68,8 +68,6 @@ spec:
         - /app/mbctl
         - -m
         - istio
-        - --ips-file
-        - /host/ips/ips.txt
         - --use-reconnect=true
         - --cni-mode=false
         lifecycle:

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -60,8 +60,6 @@ Merbridge args command
 - /app/mbctl
 - -m
 - {{ .Values.mode }}
-- --ips-file
-- {{ .Values.ipsFilePath }}
 - --use-reconnect={{ if or (eq .Values.mode "istio") (eq .Values.mode "kuma") }}true{{ else }}false{{ end }}
 - --cni-mode={{ .Values.cniMode }}
 {{- if ne .Values.mountPath.proc "/host/proc" }}
@@ -76,15 +74,6 @@ Merbridge args command
 {{- if ne .Values.mountPath.varRun "/host/var/run" }}
 - --host-var-run={{ .Values.mountPath.varRun }}
 {{- end }}
-{{- end }}
-
-{{/*
-Merbridge init args command
-*/}}
-{{- define "merbridge.cmd.init.args" -}}
-- sh
-- -c
-- nsenter --net=/host/proc/1/ns/net ip -o addr | awk '{print $4}' | tee {{ .Values.ipsFilePath }}
 {{- end }}
 
 {{/*

--- a/helm/templates/daemonset.yaml
+++ b/helm/templates/daemonset.yaml
@@ -39,8 +39,6 @@ spec:
         volumeMounts:
           - mountPath: /sys/fs/cgroup
             name: sys-fs-cgroup
-          - mountPath: /host/ips
-            name: host-ips
           - mountPath: {{ .Values.mountPath.cniBin }}
             name: cni-bin-dir
           - mountPath: {{ .Values.mountPath.cniConfig }}
@@ -50,26 +48,6 @@ spec:
           - mountPath: {{ .Values.mountPath.varRun }}
             name: host-var-run
             mountPropagation: Bidirectional
-      initContainers:
-      - image: "{{ .Values.image.hub }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
-        name: init
-        args:
-        {{- include "merbridge.cmd.init.args" . | nindent 8 }}
-        resources:
-          requests:
-            cpu: {{ .Values.resources.init.request.cpu }}
-            memory: {{ .Values.resources.init.request.memory }}
-          limits:
-            cpu: {{ .Values.resources.init.limit.cpu }}
-            memory: {{ .Values.resources.init.limit.memory }}
-        securityContext:
-          privileged: true
-        volumeMounts:
-          - mountPath: /host/ips
-            name: host-ips
-          - mountPath: {{ .Values.mountPath.proc }}
-            name: host-proc
       dnsPolicy: {{ .Values.dnsPolicy }}
       nodeSelector:
         {{- include "merbridge.nodeSelector" . | nindent 8 }}
@@ -88,8 +66,6 @@ spec:
       - hostPath:
           path: /proc
         name: host-proc
-      - emptyDir: {}
-        name: host-ips
       - hostPath:
           path: /opt/cni/bin
         name: cni-bin-dir

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -6,7 +6,6 @@
 fullname: merbridge
 namespace: istio-system
 mode: istio
-ipsFilePath: /host/ips/ips.txt
 cniMode: false
 
 # some settings of deployment
@@ -24,13 +23,6 @@ resources:
     request:
       cpu: 100m
       memory: 200Mi
-  init:
-    limit:
-      cpu: 300m
-      memory: 50Mi
-    request:
-      cpu: 100m
-      memory: 50Mi
 mountPath:
   proc: /host/proc
   cniBin: /host/opt/cni/bin

--- a/pkg/linux/file.go
+++ b/pkg/linux/file.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package linux
 
 import (

--- a/pkg/linux/ip.go
+++ b/pkg/linux/ip.go
@@ -19,11 +19,7 @@ package linux
 import (
 	"fmt"
 	"net"
-	"os"
-	"strings"
 	"unsafe"
-
-	log "github.com/sirupsen/logrus"
 )
 
 func IP2Linux(ipstr string) (uint32, error) {
@@ -32,40 +28,4 @@ func IP2Linux(ipstr string) (uint32, error) {
 		return 0, fmt.Errorf("error parse ip: %s", ipstr)
 	}
 	return *(*uint32)(unsafe.Pointer(&ip[12])), nil
-}
-
-func IsCurrentNodeIP(ipstr string, ipListFile string) bool {
-	if ipListFile != "" {
-		// exists
-		bs, err := os.ReadFile(ipListFile)
-		if err != nil {
-			log.Errorf("read ip list file from %s error: %v", ipListFile, err)
-		} else {
-			for _, line := range strings.Split(string(bs), "\n") {
-				if strings.HasPrefix(line, ipstr+"/") {
-					return true
-				}
-			}
-			return false
-		}
-	}
-	log.Debugf("no ips file found, fetch ips from interfaces")
-	ifaces, _ := net.Interfaces() // todo: handle err
-	for _, i := range ifaces {
-		addrs, _ := i.Addrs() // todo: handle err
-		for _, addr := range addrs {
-			switch v := addr.(type) {
-			case *net.IPNet:
-				if v.IP.String() == ipstr {
-					return true
-				}
-			case *net.IPAddr:
-				if v.String() == ipstr {
-					return true
-				}
-			}
-			// todo: process IP address
-		}
-	}
-	return false
 }


### PR DESCRIPTION
Daemon pods share the same UTS namespace with the host, so we can watch pods filtered by the hostname
This will bring 2 benefits:
1. The informer only watches a subset of pods, it will reduce memory usage and unnecessary reconciling
2. Get rid of fetching the host ip, which makes merbridge start faster in my env.