### PR TITLE
Pick interfaces smarter

### DIFF
--- a/internal/cni-server/cni-plugin.go
+++ b/internal/cni-server/cni-plugin.go
@@ -87,9 +87,13 @@ func (s *server) CmdAdd(args *skel.CmdArgs) (err error) {
 			return err
 		}
 		// attach tc to the device
+		if len(args.IfName) != 0 {
+			return s.attachTC(netns.Path(), args.IfName)
+		}
+		// interface not specified, should not happen?
 		ifaces, _ := net.Interfaces()
 		for _, iface := range ifaces {
-			if iface.Name != "lo" {
+			if (iface.Flags&net.FlagLoopback) == 0 && (iface.Flags&net.FlagUp) != 0 {
 				return s.attachTC(netns.Path(), iface.Name)
 			}
 		}
@@ -224,7 +228,7 @@ func (s *server) checkAndRepairPodPrograms() error {
 				// attach tc to the device
 				ifaces, _ := net.Interfaces()
 				for _, iface := range ifaces {
-					if iface.Name != "lo" {
+					if (iface.Flags&net.FlagLoopback) == 0 && (iface.Flags&net.FlagUp) != 0 {
 						return s.attachTC(netns.Path(), iface.Name)
 					}
 				}


### PR DESCRIPTION
In calico ipip mode, each pod has `tunl0` inside
https://github.com/projectcalico/calico/issues/2156#issuecomment-418537325

For example:
```sh
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN qlen 1
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host
       valid_lft forever preferred_lft forever
2: tunl0@NONE: <NOARP> mtu 1480 qdisc noop state DOWN qlen 1
    link/ipip 0.0.0.0 brd 0.0.0.0
4: eth0@if31: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1480 qdisc noqueue state UP
    link/ether 7a:9e:e8:28:b2:6f brd ff:ff:ff:ff:ff:ff link-netnsid 0
    inet 100.103.244.106/32 scope global eth0
       valid_lft forever preferred_lft forever
    inet6 fe80::789e:e8ff:fe28:b26f/64 scope link
       valid_lft forever preferred_lft forever
```
This patch is aimed to make the interface selection a bit smarter