### PR TITLE
Fix exclude inbound ports

### DIFF
--- a/controller/localip/localip.go
+++ b/controller/localip/localip.go
@@ -186,7 +186,7 @@ func parsePodConfigFromAnnotations(annotations map[string]string, pod *podConfig
 		}
 	}
 	pod.statusPort = uint16(statusPort)
-	excludeInboundPorts := []uint16{15090, 15006, 15001, 15000, 15020} // todo changeme
+	excludeInboundPorts := []uint16{15006, 15001, 15008, 15090, 15021, 15020, 15000} // todo changeme
 	if v, ok := annotations["traffic.sidecar.istio.io/excludeInboundPorts"]; ok {
 		excludeInboundPorts = append(excludeInboundPorts, getPortsFromString(v)...)
 	}

--- a/controller/localip/localip_test.go
+++ b/controller/localip/localip_test.go
@@ -34,7 +34,7 @@ func Test_parseConfig(t *testing.T) {
 			expect: &podConfig{
 				statusPort: 15021,
 				excludeInPorts: [MaxItemLen]uint16{
-					15090, 15006, 15001, 15000, 15020,
+					15006, 15001, 15008, 15090, 15021, 15020, 15000,
 				},
 			},
 		},
@@ -46,7 +46,7 @@ func Test_parseConfig(t *testing.T) {
 			expect: &podConfig{
 				statusPort: 15021,
 				excludeInPorts: [MaxItemLen]uint16{
-					15090, 15006, 15001, 15000, 15020,
+					15006, 15001, 15008, 15090, 15021, 15020, 15000,
 					12345,
 					80,
 				},
@@ -60,7 +60,7 @@ func Test_parseConfig(t *testing.T) {
 			expect: &podConfig{
 				statusPort: 15021,
 				excludeInPorts: [MaxItemLen]uint16{
-					15090, 15006, 15001, 15000, 15020,
+					15006, 15001, 15008, 15090, 15021, 15020, 15000,
 				},
 				excludeOutRanges: [MaxItemLen]cidr{
 					{
@@ -82,7 +82,7 @@ func Test_parseConfig(t *testing.T) {
 			expect: &podConfig{
 				statusPort: 15021,
 				excludeInPorts: [MaxItemLen]uint16{
-					15090, 15006, 15001, 15000, 15020,
+					15006, 15001, 15008, 15090, 15021, 15020, 15000,
 				},
 				excludeOutRanges: [MaxItemLen]cidr{
 					{
@@ -100,7 +100,7 @@ func Test_parseConfig(t *testing.T) {
 			expect: &podConfig{
 				statusPort: 15021,
 				excludeInPorts: [MaxItemLen]uint16{
-					15090, 15006, 15001, 15000, 15020,
+					15006, 15001, 15008, 15090, 15021, 15020, 15000,
 				},
 				excludeOutRanges: [MaxItemLen]cidr{
 					{


### PR DESCRIPTION
We are missing some auto-excluded inbound ports
See https://github.com/istio/istio/blob/1.14.3/cni/pkg/plugin/redirect.go#L252 and https://github.com/istio/istio/blob/1.14.3/tools/istio-iptables/pkg/capture/run.go#L353