### PR TITLE
Check existing pods after cni is ready

### DIFF
--- a/controller/pod_test.go
+++ b/controller/pod_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package localip
+package controller
 
 import (
 	"testing"

--- a/controller/start.go
+++ b/controller/start.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/merbridge/merbridge/app/cmd/options"
 	"github.com/merbridge/merbridge/config"
-	"github.com/merbridge/merbridge/controller/localip"
 	"github.com/merbridge/merbridge/pkg/kube"
 )
 
@@ -45,7 +44,7 @@ func Run(cniReady chan struct{}, stop chan struct{}) error {
 	}
 
 	// run local ip controller
-	if err = localip.RunLocalIPController(client, cniReady, stop); err != nil {
+	if err = RunLocalPodController(client, stop); err != nil {
 		return fmt.Errorf("run local ip controller error: %v", err)
 	}
 


### PR DESCRIPTION
If a pod is created between `checkAndRepairPodPrograms` and `installCNI`, the tc programs will not be attached to it, so we must ensure cni is ready before `checkAndRepairPodPrograms`