### PR TITLE
use cgroup_ips map to improve mb_connect performance

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -63,7 +63,7 @@ jobs:
         kubectl exec $(kubectl get po -l app=sleep -o=jsonpath='{..metadata.name}') -c sleep -- curl -s -v helloworld:5000/hello
     - name: install merbridge
       run: |
-        nohup go run -exec sudo ./app/main.go -k -m istio -d > mbctl.log &
+        nohup go run -exec sudo ./app/main.go -k -m istio --cni-mode=true -d > mbctl.log &
         while true; do [ "$(cat mbctl.log | grep 'Pod Watcher Ready')" = "" ] || break && (echo waiting for mbctl watcher ready; sleep 3); done
     - name: test connect with Merbridge
       run: |

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -14,8 +14,8 @@ jobs:
     timeout-minutes: 30
     if: ${{ contains(github.event.pull_request.labels.*.name, 'needs-e2e-test') }}
     env: 
-      ISTIO_VERSION: '1.12.2'
-      KIND_VERSION: v0.11.1
+      ISTIO_VERSION: '1.15.2'
+      KIND_VERSION: v0.16.0
       KERNEL_VERSION: v5.4
     steps:
     - uses: actions/checkout@v3
@@ -65,12 +65,9 @@ jobs:
       run: |
         nohup go run -exec sudo ./app/main.go -k -m istio -d > mbctl.log &
         while true; do [ "$(cat mbctl.log | grep 'Pod Watcher Ready')" = "" ] || break && (echo waiting for mbctl watcher ready; sleep 3); done
-    - name: Setup upterm session
-      uses: lhotari/action-upterm@v1
     - name: test connect with Merbridge
       run: |
         set -x
-        sleep 100000000
         kubectl exec $(kubectl get po -l app=sleep -o=jsonpath='{..metadata.name}') -c sleep -- curl -s -v helloworld:5000/hello
         sudo cat /sys/kernel/debug/tracing/trace > /tmp/trace-log
         # check if eBPF works
@@ -87,7 +84,7 @@ jobs:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'needs-e2e-test') }}
     env:
       KUMA_VERSION: '1.7.0'
-      KIND_VERSION: v0.11.1
+      KIND_VERSION: v0.16.0
       KERNEL_VERSION: v5.4
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -91,7 +91,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18
+        go-version: 1.19
     - name: install bpftool
       run: |
         sudo bash ./scripts/build-bpftool.sh

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -63,11 +63,14 @@ jobs:
         kubectl exec $(kubectl get po -l app=sleep -o=jsonpath='{..metadata.name}') -c sleep -- curl -s -v helloworld:5000/hello
     - name: install merbridge
       run: |
-        nohup go run -exec sudo ./app/main.go -k -m istio --cni-mode=true -d > mbctl.log &
+        nohup go run -exec sudo ./app/main.go -k -m istio -d > mbctl.log &
         while true; do [ "$(cat mbctl.log | grep 'Pod Watcher Ready')" = "" ] || break && (echo waiting for mbctl watcher ready; sleep 3); done
+    - name: Setup upterm session
+      uses: lhotari/action-upterm@v1
     - name: test connect with Merbridge
       run: |
         set -x
+        sleep 100000000
         kubectl exec $(kubectl get po -l app=sleep -o=jsonpath='{..metadata.name}') -c sleep -- curl -s -v helloworld:5000/hello
         sudo cat /sys/kernel/debug/tracing/trace > /tmp/trace-log
         # check if eBPF works

--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -96,8 +96,8 @@ load-map-local_pod_ips:
 load-map-process_ip:
 	[ -f $(PROG_MOUNT_PATH)/process_ip ] || sudo bpftool map create $(PROG_MOUNT_PATH)/process_ip type lru_hash key 4 value 4 entries 1024 name process_ip
 
-load-map-cgroup_ips:
-	[ -f $(PROG_MOUNT_PATH)/cgroup_ips ] || sudo bpftool map create $(PROG_MOUNT_PATH)/cgroup_ips type lru_hash key 8 value 16 entries 1024 name cgroup_ips
+load-map-cgroup_info_map:
+	[ -f $(PROG_MOUNT_PATH)/cgroup_info_map ] || sudo bpftool map create $(PROG_MOUNT_PATH)/cgroup_info_map type lru_hash key 8 value 24 entries 1024 name cgroup_info_map
 
 load-map-mark_pod_ips_map:
 	[ -f $(PROG_MOUNT_PATH)/mark_pod_ips_map ] || sudo bpftool map create $(PROG_MOUNT_PATH)/mark_pod_ips_map type hash key 4 value 16 entries 65535 name mark_pod_ips_map
@@ -114,7 +114,7 @@ clean-maps:
 		$(PROG_MOUNT_PATH)/sock_pair_map \
 		$(PROG_MOUNT_PATH)/pair_original_dst \
 		$(PROG_MOUNT_PATH)/process_ip \
-		$(PROG_MOUNT_PATH)/cgroup_ips \
+		$(PROG_MOUNT_PATH)/cgroup_info_map \
 		$(PROG_MOUNT_PATH)/local_pod_ips \
 		$(PROG_MOUNT_PATH)/cookie_original_dst \
 		$(PROG_MOUNT_PATH)/mark_pod_ips_map
@@ -141,13 +141,13 @@ clean-redir:
 	sudo bpftool prog detach pinned $(PROG_MOUNT_PATH)/redir msg_verdict pinned $(PROG_MOUNT_PATH)/sock_pair_map
 	sudo rm $(PROG_MOUNT_PATH)/redir
 
-load-connect: load-map-cookie_original_dst load-map-local_pod_ips load-map-process_ip load-map-cgroup_ips load-map-mark_pod_ips_map
+load-connect: load-map-cookie_original_dst load-map-local_pod_ips load-map-process_ip load-map-cgroup_info_map load-map-mark_pod_ips_map
 	sudo bpftool -m prog loadall mb_connect.o $(PROG_MOUNT_PATH)/connect \
 		map name cookie_original_dst pinned $(PROG_MOUNT_PATH)/cookie_original_dst \
 		map name local_pod_ips pinned $(PROG_MOUNT_PATH)/local_pod_ips \
 		map name mark_pod_ips_map pinned $(PROG_MOUNT_PATH)/mark_pod_ips_map \
 		map name process_ip pinned $(PROG_MOUNT_PATH)/process_ip \
-		map name cgroup_ips pinned $(PROG_MOUNT_PATH)/cgroup_ips
+		map name cgroup_info_map pinned $(PROG_MOUNT_PATH)/cgroup_info_map
 
 attach-connect:
 ifeq ($(ENABLE_IPV4),true)
@@ -196,9 +196,11 @@ ifeq ($(ENABLE_IPV4),true)
 	sudo rm -rf $(PROG_MOUNT_PATH)/bind
 endif
 
-load-sendmsg: load-map-cookie_original_dst
+load-sendmsg: load-map-cookie_original_dst load-map-cgroup_info_map load-map-mark_pod_ips_map
 	sudo bpftool -m prog loadall mb_sendmsg.o $(PROG_MOUNT_PATH)/sendmsg \
-		map name cookie_original_dst pinned $(PROG_MOUNT_PATH)/cookie_original_dst
+		map name cookie_original_dst pinned $(PROG_MOUNT_PATH)/cookie_original_dst \
+		map name mark_pod_ips_map pinned $(PROG_MOUNT_PATH)/mark_pod_ips_map \
+		map name cgroup_info_map pinned $(PROG_MOUNT_PATH)/cgroup_info_map
 
 attach-sendmsg:
 ifeq ($(ENABLE_IPV4),true)
@@ -217,9 +219,11 @@ ifeq ($(ENABLE_IPV6),true)
 endif
 	sudo rm -rf $(PROG_MOUNT_PATH)/sendmsg
 
-load-recvmsg: load-map-cookie_original_dst
+load-recvmsg: load-map-cookie_original_dst load-map-cgroup_info_map load-map-mark_pod_ips_map
 	sudo bpftool -m prog loadall mb_recvmsg.o $(PROG_MOUNT_PATH)/recvmsg \
-		map name cookie_original_dst pinned $(PROG_MOUNT_PATH)/cookie_original_dst
+		map name cookie_original_dst pinned $(PROG_MOUNT_PATH)/cookie_original_dst \
+		map name mark_pod_ips_map pinned $(PROG_MOUNT_PATH)/mark_pod_ips_map \
+		map name cgroup_info_map pinned $(PROG_MOUNT_PATH)/cgroup_info_map
 
 attach-recvmsg:
 ifeq ($(ENABLE_IPV4),true)

--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -96,6 +96,9 @@ load-map-local_pod_ips:
 load-map-process_ip:
 	[ -f $(PROG_MOUNT_PATH)/process_ip ] || sudo bpftool map create $(PROG_MOUNT_PATH)/process_ip type lru_hash key 4 value 4 entries 1024 name process_ip
 
+load-map-cgroup_ips:
+	[ -f $(PROG_MOUNT_PATH)/cgroup_ips ] || sudo bpftool map create $(PROG_MOUNT_PATH)/cgroup_ips type lru_hash key 8 value 16 entries 1024 name cgroup_ips
+
 load-map-mark_pod_ips_map:
 	[ -f $(PROG_MOUNT_PATH)/mark_pod_ips_map ] || sudo bpftool map create $(PROG_MOUNT_PATH)/mark_pod_ips_map type hash key 4 value 16 entries 65535 name mark_pod_ips_map
 
@@ -111,6 +114,7 @@ clean-maps:
 		$(PROG_MOUNT_PATH)/sock_pair_map \
 		$(PROG_MOUNT_PATH)/pair_original_dst \
 		$(PROG_MOUNT_PATH)/process_ip \
+		$(PROG_MOUNT_PATH)/cgroup_ips \
 		$(PROG_MOUNT_PATH)/local_pod_ips \
 		$(PROG_MOUNT_PATH)/cookie_original_dst \
 		$(PROG_MOUNT_PATH)/mark_pod_ips_map
@@ -137,12 +141,13 @@ clean-redir:
 	sudo bpftool prog detach pinned $(PROG_MOUNT_PATH)/redir msg_verdict pinned $(PROG_MOUNT_PATH)/sock_pair_map
 	sudo rm $(PROG_MOUNT_PATH)/redir
 
-load-connect: load-map-cookie_original_dst load-map-local_pod_ips load-map-process_ip load-map-mark_pod_ips_map
+load-connect: load-map-cookie_original_dst load-map-local_pod_ips load-map-process_ip load-map-cgroup_ips load-map-mark_pod_ips_map
 	sudo bpftool -m prog loadall mb_connect.o $(PROG_MOUNT_PATH)/connect \
 		map name cookie_original_dst pinned $(PROG_MOUNT_PATH)/cookie_original_dst \
 		map name local_pod_ips pinned $(PROG_MOUNT_PATH)/local_pod_ips \
 		map name mark_pod_ips_map pinned $(PROG_MOUNT_PATH)/mark_pod_ips_map \
-		map name process_ip pinned $(PROG_MOUNT_PATH)/process_ip
+		map name process_ip pinned $(PROG_MOUNT_PATH)/process_ip \
+		map name cgroup_ips pinned $(PROG_MOUNT_PATH)/cgroup_ips
 
 attach-connect:
 ifeq ($(ENABLE_IPV4),true)

--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -97,7 +97,7 @@ load-map-process_ip:
 	[ -f $(PROG_MOUNT_PATH)/process_ip ] || sudo bpftool map create $(PROG_MOUNT_PATH)/process_ip type lru_hash key 4 value 4 entries 1024 name process_ip
 
 load-map-cgroup_info_map:
-	[ -f $(PROG_MOUNT_PATH)/cgroup_info_map ] || sudo bpftool map create $(PROG_MOUNT_PATH)/cgroup_info_map type lru_hash key 8 value 24 entries 1024 name cgroup_info_map
+	[ -f $(PROG_MOUNT_PATH)/cgroup_info_map ] || sudo bpftool map create $(PROG_MOUNT_PATH)/cgroup_info_map type lru_hash key 8 value 32 entries 1024 name cgroup_info_map
 
 load-map-mark_pod_ips_map:
 	[ -f $(PROG_MOUNT_PATH)/mark_pod_ips_map ] || sudo bpftool map create $(PROG_MOUNT_PATH)/mark_pod_ips_map type hash key 4 value 16 entries 65535 name mark_pod_ips_map

--- a/bpf/headers/cgroup.h
+++ b/bpf/headers/cgroup.h
@@ -75,7 +75,6 @@ static inline int get_current_cgroup_info(void *ctx,
     } else {
         *cg_info = *(struct cgroup_info *)info;
     }
-    debugf("pid: %d, cgroup(%ld) is in mesh: %d", bpf_get_current_pid_tgid() >> 32, cgroup_id, cg_info->is_in_mesh);
     return 1;
 }
 

--- a/bpf/headers/cgroup.h
+++ b/bpf/headers/cgroup.h
@@ -1,0 +1,100 @@
+/*
+Copyright © 2022 Merbridge Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+#include "helpers.h"
+#include "maps.h"
+#include "mesh.h"
+#include <linux/bpf.h>
+
+#define IP_DETECTED_FLAG (1 << 0)
+#define DNS_CAPTURE_PORT_FLAG (1 << 1)
+
+static inline struct cgroup_info get_current_cgroup_info(void *ctx)
+{
+    struct cgroup_info cg_info = {
+        .is_in_mesh = 0,
+        .cgroup_ip = {0, 0, 0, 0},
+        .flags = 0,
+        .detected_flags = 0,
+    };
+    __u64 cgroup_id = bpf_get_current_cgroup_id();
+    void *info = bpf_map_lookup_elem(&cgroup_info_map, &cgroup_id);
+    if (!info) {
+        // not checked ever
+        if (!is_port_listen_current_ns(ctx, ip_zero, OUT_REDIRECT_PORT)) {
+            // not in mesh
+            cg_info.is_in_mesh = 0;
+        } else {
+            cg_info.is_in_mesh = 1;
+            // get ip addresses of current pod/ns.
+            struct bpf_sock_tuple tuple = {};
+            tuple.ipv4.dport = bpf_htons(SOCK_IP_MARK_PORT);
+            tuple.ipv4.daddr = 0;
+            struct bpf_sock *s = bpf_sk_lookup_tcp(
+                ctx, &tuple, sizeof(tuple.ipv4), BPF_F_CURRENT_NETNS, 0);
+            if (s) {
+                __u32 curr_ip_mark = s->mark;
+                bpf_sk_release(s);
+                __u32 *ip = (__u32 *)bpf_map_lookup_elem(&mark_pod_ips_map,
+                                                         &curr_ip_mark);
+                if (!ip) {
+                    debugf("get ip for mark 0x%x error", curr_ip_mark);
+                } else {
+                    set_ipv6(cg_info.cgroup_ip, ip); // network order
+                }
+            }
+            cg_info.detected_flags |= IP_DETECTED_FLAG;
+        }
+        bpf_map_update_elem(&cgroup_info_map, &cgroup_id, &cg_info, BPF_ANY);
+    } else {
+        cg_info = *(struct cgroup_info *)info;
+    }
+    return cg_info;
+}
+
+// is_port_listen_in_cgroup is used to detect whether a port is listened to in
+// the current cgroup, using cgroup_info_map for caching.
+static inline int is_port_listen_in_cgroup(void *ctx, __u16 is_tcp, __u32 ip,
+                                           __u16 port, __u16 port_flag)
+{
+    struct cgroup_info cg_info = get_current_cgroup_info(ctx);
+    if (!cg_info.is_in_mesh) {
+        return 0;
+    }
+    if (cg_info.detected_flags & port_flag) {
+        if (cg_info.flags & port_flag) {
+            return 1;
+        }
+        return 0;
+    }
+    // need detect
+    int listen;
+    if (is_tcp) {
+        listen = is_port_listen_current_ns(ctx, ip, port);
+    } else {
+        listen = is_port_listen_udp_current_ns(ctx, ip, port);
+    }
+    cg_info.detected_flags |= port_flag;
+    if (listen)
+        cg_info.flags |= port_flag;
+    __u64 cgroup_id = bpf_get_current_cgroup_id();
+    bpf_map_update_elem(&cgroup_info_map, &cgroup_id, &cg_info, BPF_ANY);
+    if (cg_info.flags & port_flag) {
+        return 1;
+    }
+    return 0;
+}

--- a/bpf/headers/helpers.h
+++ b/bpf/headers/helpers.h
@@ -92,7 +92,7 @@ static long (*bpf_sock_hash_update)(
 static long (*bpf_msg_redirect_hash)(
     struct sk_msg_md *md, struct bpf_elf_map *map, void *key,
     __u64 flags) = (void *)BPF_FUNC_msg_redirect_hash;
-static long (*bpf_bind)(struct bpf_sock_addr *ctx, struct sockaddr *addr,
+static long (*bpf_bind)(struct bpf_sock_addr *ctx, struct sockaddr_in *addr,
                         int addr_len) = (void *)BPF_FUNC_bind;
 static long (*bpf_l4_csum_replace)(struct __sk_buff *skb, __u32 offset,
                                    __u64 from, __u64 to, __u64 flags) = (void *)
@@ -234,6 +234,22 @@ struct pair {
     __u32 dip[4];
     __u16 sport;
     __u16 dport;
+};
+
+struct cgroup_info {
+    __u32 is_in_mesh;
+    __u32 cgroup_ip[4];
+    // We can't specify which ports are listened to here, so we open up a flags,
+    // user-defined. E.g, for those who wish to determine if port 15001 is
+    // listened to, we can customize a flag, `IS_LISTEN_15001 = 1 << 2`, which
+    // we can subsequently detect by `flags & IS_LISTEN_15001`.
+    __u16 flags;
+    // detected_flags is used to determine if this operation has ever been
+    // performed. if `flags & IS_LISTEN_15001` is false but `detected_flags &
+    // IS_LISTEN_15001` is true, that means real true, we do not need recheck.
+    // but if `detected_flags & IS_LISTEN_15001` is false, that probably means
+    // we haven't tested it and need to retest it.
+    __u16 detected_flags;
 };
 
 #define MAX_ITEM_LEN 10

--- a/bpf/headers/helpers.h
+++ b/bpf/headers/helpers.h
@@ -60,6 +60,8 @@ static __u64 (*bpf_get_current_pid_tgid)() = (void *)
     BPF_FUNC_get_current_pid_tgid;
 static __u64 (*bpf_get_current_uid_gid)() = (void *)
     BPF_FUNC_get_current_uid_gid;
+static __u64 (*bpf_get_current_cgroup_id)() = (void *)
+    BPF_FUNC_get_current_cgroup_id;
 static void (*bpf_trace_printk)(const char *fmt, int fmt_size,
                                 ...) = (void *)BPF_FUNC_trace_printk;
 static __u64 (*bpf_get_current_comm)(void *buf, __u32 size_of_buf) = (void *)

--- a/bpf/headers/helpers.h
+++ b/bpf/headers/helpers.h
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 #pragma once
+#include <asm-generic/int-ll64.h>
 #include <linux/bpf.h>
 #include <linux/bpf_common.h>
 #include <linux/in.h>
@@ -237,6 +238,7 @@ struct pair {
 };
 
 struct cgroup_info {
+    __u64 id;
     __u32 is_in_mesh;
     __u32 cgroup_ip[4];
     // We can't specify which ports are listened to here, so we open up a flags,

--- a/bpf/headers/maps.h
+++ b/bpf/headers/maps.h
@@ -44,7 +44,8 @@ struct bpf_elf_map __section("maps") process_ip = {
     .max_elem = 1024,
 };
 
-// process_ip stores envoy's ip address.
+// cgroup_ips caches the ip address of each cgroup, which is used to speed up
+// the connect process.
 struct bpf_elf_map __section("maps") cgroup_ips = {
     .type = BPF_MAP_TYPE_LRU_HASH,
     .size_key = sizeof(__u64),

--- a/bpf/headers/maps.h
+++ b/bpf/headers/maps.h
@@ -44,6 +44,14 @@ struct bpf_elf_map __section("maps") process_ip = {
     .max_elem = 1024,
 };
 
+// process_ip stores envoy's ip address.
+struct bpf_elf_map __section("maps") cgroup_ips = {
+    .type = BPF_MAP_TYPE_LRU_HASH,
+    .size_key = sizeof(__u64),
+    .size_value = sizeof(__u32) * 4,
+    .max_elem = 1024,
+};
+
 struct bpf_elf_map __section("maps") pair_original_dst = {
     .type = BPF_MAP_TYPE_LRU_HASH,
     .size_key = sizeof(struct pair),

--- a/bpf/headers/maps.h
+++ b/bpf/headers/maps.h
@@ -46,10 +46,10 @@ struct bpf_elf_map __section("maps") process_ip = {
 
 // cgroup_ips caches the ip address of each cgroup, which is used to speed up
 // the connect process.
-struct bpf_elf_map __section("maps") cgroup_ips = {
+struct bpf_elf_map __section("maps") cgroup_info_map = {
     .type = BPF_MAP_TYPE_LRU_HASH,
     .size_key = sizeof(__u64),
-    .size_value = sizeof(__u32) * 4,
+    .size_value = sizeof(struct cgroup_info),
     .max_elem = 1024,
 };
 

--- a/bpf/headers/mesh.h
+++ b/bpf/headers/mesh.h
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
+#pragma once
 #define SOCK_IP_MARK_PORT 39807
 
 #define ISTIO 1

--- a/bpf/mb_connect.c
+++ b/bpf/mb_connect.c
@@ -60,7 +60,10 @@ static inline int udp_connect4(struct bpf_sock_addr *ctx)
 
 static inline int tcp_connect4(struct bpf_sock_addr *ctx)
 {
-    struct cgroup_info cg_info = get_current_cgroup_info(ctx);
+    struct cgroup_info cg_info;
+    if (!get_current_cgroup_info(ctx, &cg_info)) {
+        return 1;
+    }
     if (!cg_info.is_in_mesh) {
         // bypass normal traffic. we only deal pod's
         // traffic managed by istio or kuma.

--- a/bpf/mb_connect.c
+++ b/bpf/mb_connect.c
@@ -67,24 +67,36 @@ static inline int tcp_connect4(struct bpf_sock_addr *ctx)
     }
     __u32 curr_pod_ip = 0;
     __u32 _curr_pod_ip[4];
-    {
-        // get ip addresses of current pod/ns.
-        struct bpf_sock_tuple tuple = {};
-        tuple.ipv4.dport = bpf_htons(SOCK_IP_MARK_PORT);
-        tuple.ipv4.daddr = 0;
-        struct bpf_sock *s = bpf_sk_lookup_tcp(ctx, &tuple, sizeof(tuple.ipv4),
-                                               BPF_F_CURRENT_NETNS, 0);
-        if (s) {
-            __u32 curr_ip_mark = s->mark;
-            bpf_sk_release(s);
-            __u32 *ip = bpf_map_lookup_elem(&mark_pod_ips_map, &curr_ip_mark);
-            if (ip) {
-                set_ipv6(_curr_pod_ip, ip); // network order
-                curr_pod_ip = get_ipv4(ip);
-            } else {
-                debugf("get ip for mark %x error", curr_ip_mark);
+    { 
+        // check cache
+        __u64 cgroup_id = bpf_get_current_cgroup_id();
+        __u32 *ip = bpf_map_lookup_elem(&cgroup_ips, &cgroup_id);
+        if (!ip) {
+            debugf("can not get current cgroup(%ld)'s ip from map, try to fetch from sock", cgroup_id);
+            // get ip addresses of current pod/ns.
+            struct bpf_sock_tuple tuple = {};
+            tuple.ipv4.dport = bpf_htons(SOCK_IP_MARK_PORT);
+            tuple.ipv4.daddr = 0;
+            struct bpf_sock *s = bpf_sk_lookup_tcp(ctx, &tuple, sizeof(tuple.ipv4),
+                                                BPF_F_CURRENT_NETNS, 0);
+            if (s) {
+                __u32 curr_ip_mark = s->mark;
+                bpf_sk_release(s);
+                ip = bpf_map_lookup_elem(&mark_pod_ips_map, &curr_ip_mark);
+                if (!ip) {
+                    debugf("get ip for mark %x error", curr_ip_mark);
+                } else {
+                    // store to cache
+                    bpf_map_update_elem(&cgroup_ips, &cgroup_id, ip, BPF_ANY);
+                }
             }
+        } else {
+            debugf("got ip %pI4 of cgroup(%ld) from map", ip, cgroup_id);
         }
+        if (ip) {
+            set_ipv6(_curr_pod_ip, ip); // network order
+            curr_pod_ip = get_ipv4(ip);
+        } 
     }
 
     if (curr_pod_ip == 0) {

--- a/bpf/mb_connect.c
+++ b/bpf/mb_connect.c
@@ -67,18 +67,20 @@ static inline int tcp_connect4(struct bpf_sock_addr *ctx)
     }
     __u32 curr_pod_ip = 0;
     __u32 _curr_pod_ip[4];
-    { 
+    {
         // check cache
         __u64 cgroup_id = bpf_get_current_cgroup_id();
         __u32 *ip = bpf_map_lookup_elem(&cgroup_ips, &cgroup_id);
         if (!ip) {
-            debugf("can not get current cgroup(%ld)'s ip from map, try to fetch from sock", cgroup_id);
+            debugf("can not get current cgroup(%ld)'s ip from map, try to "
+                   "fetch from sock",
+                   cgroup_id);
             // get ip addresses of current pod/ns.
             struct bpf_sock_tuple tuple = {};
             tuple.ipv4.dport = bpf_htons(SOCK_IP_MARK_PORT);
             tuple.ipv4.daddr = 0;
-            struct bpf_sock *s = bpf_sk_lookup_tcp(ctx, &tuple, sizeof(tuple.ipv4),
-                                                BPF_F_CURRENT_NETNS, 0);
+            struct bpf_sock *s = bpf_sk_lookup_tcp(
+                ctx, &tuple, sizeof(tuple.ipv4), BPF_F_CURRENT_NETNS, 0);
             if (s) {
                 __u32 curr_ip_mark = s->mark;
                 bpf_sk_release(s);
@@ -96,7 +98,7 @@ static inline int tcp_connect4(struct bpf_sock_addr *ctx)
         if (ip) {
             set_ipv6(_curr_pod_ip, ip); // network order
             curr_pod_ip = get_ipv4(ip);
-        } 
+        }
     }
 
     if (curr_pod_ip == 0) {

--- a/bpf/mb_recvmsg.c
+++ b/bpf/mb_recvmsg.c
@@ -30,7 +30,8 @@ __section("cgroup/recvmsg4") int mb_recvmsg4(struct bpf_sock_addr *ctx)
     if (bpf_htons(ctx->user_port) != DNS_CAPTURE_PORT) {
         return 1;
     }
-    if (!is_port_listen_in_cgroup(ctx, 0, localhost, DNS_CAPTURE_PORT, DNS_CAPTURE_PORT_FLAG)) {
+    if (!is_port_listen_in_cgroup(ctx, 0, localhost, DNS_CAPTURE_PORT,
+                                  DNS_CAPTURE_PORT_FLAG)) {
         // printk("not from pod");
         return 1;
     }

--- a/bpf/mb_recvmsg.c
+++ b/bpf/mb_recvmsg.c
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+#include "headers/cgroup.h"
 #include "headers/helpers.h"
 #include "headers/maps.h"
 #include "headers/mesh.h"
@@ -29,8 +30,7 @@ __section("cgroup/recvmsg4") int mb_recvmsg4(struct bpf_sock_addr *ctx)
     if (bpf_htons(ctx->user_port) != DNS_CAPTURE_PORT) {
         return 1;
     }
-    if (!(is_port_listen_current_ns(ctx, ip_zero, OUT_REDIRECT_PORT) &&
-          is_port_listen_udp_current_ns(ctx, localhost, DNS_CAPTURE_PORT))) {
+    if (!is_port_listen_in_cgroup(ctx, 0, localhost, DNS_CAPTURE_PORT, DNS_CAPTURE_PORT_FLAG)) {
         // printk("not from pod");
         return 1;
     }

--- a/bpf/mb_sendmsg.c
+++ b/bpf/mb_sendmsg.c
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+#include "headers/cgroup.h"
 #include "headers/helpers.h"
 #include "headers/maps.h"
 #include "headers/mesh.h"
@@ -29,8 +30,7 @@ __section("cgroup/sendmsg4") int mb_sendmsg4(struct bpf_sock_addr *ctx)
     if (bpf_htons(ctx->user_port) != 53) {
         return 1;
     }
-    if (!(is_port_listen_current_ns(ctx, ip_zero, OUT_REDIRECT_PORT) &&
-          is_port_listen_udp_current_ns(ctx, localhost, DNS_CAPTURE_PORT))) {
+    if (!is_port_listen_in_cgroup(ctx, 0, localhost, DNS_CAPTURE_PORT, DNS_CAPTURE_PORT_FLAG)) {
         // this query is not from mesh injected pod, or DNS CAPTURE not enabled.
         // we do nothing.
         return 1;

--- a/bpf/mb_sendmsg.c
+++ b/bpf/mb_sendmsg.c
@@ -30,7 +30,8 @@ __section("cgroup/sendmsg4") int mb_sendmsg4(struct bpf_sock_addr *ctx)
     if (bpf_htons(ctx->user_port) != 53) {
         return 1;
     }
-    if (!is_port_listen_in_cgroup(ctx, 0, localhost, DNS_CAPTURE_PORT, DNS_CAPTURE_PORT_FLAG)) {
+    if (!is_port_listen_in_cgroup(ctx, 0, localhost, DNS_CAPTURE_PORT,
+                                  DNS_CAPTURE_PORT_FLAG)) {
         // this query is not from mesh injected pod, or DNS CAPTURE not enabled.
         // we do nothing.
         return 1;

--- a/scripts/build-bpftool.sh
+++ b/scripts/build-bpftool.sh
@@ -16,7 +16,7 @@
 set -ex
 
 if [ -z "$KERNEL_VERSION" ]; then
-    KERNEL_VERSION=v5.4
+    KERNEL_VERSION=v5.7
 fi
 if [ -z "$SKIP_INSTALL" ]; then
     apt update

--- a/scripts/setup-kind.sh
+++ b/scripts/setup-kind.sh
@@ -16,7 +16,7 @@
 set -ex
 
 NAME=${1:-merbridge}
-KIND_VERSION=${KIND_VERSION:-v0.11.1}
+KIND_VERSION=${KIND_VERSION:-v0.16.0}
 if [ -z "$SKIP_INSTALL" ]; then
     curl -Lo ./kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-$(uname)-amd64"
     chmod +x ./kind


### PR DESCRIPTION
bpf_sk_lookup_tcp may cost 50-150ns per ops, It is more expensive.

Without cache:
```
 kebe@Kebe-DaoCloud-PC  ~/workspace/mebpf   main ±  sudo go test -bench .
goos: linux
goarch: amd64
pkg: github.com/merbridge/merbridge
cpu: AMD Ryzen 9 3900 12-Core Processor             
BenchmarkConnect/eBPF-24                1000000000               0.4532 ns/op
BenchmarkConnect/eBPF/mb_sock_connect        108              3203 ns/op
BenchmarkSockops/eBPF-24                1000000000               0.4327 ns/op
BenchmarkSockops/eBPF/mb_sockops             954               689.2 ns/op
PASS
ok      github.com/merbridge/merbridge  20.530s
```

After cached:
```
 kebe@Kebe-DaoCloud-PC  ~/workspace/mebpf   main ±  sudo go test -bench .
goos: linux
goarch: amd64
pkg: github.com/merbridge/merbridge
cpu: AMD Ryzen 9 3900 12-Core Processor             
BenchmarkConnect/eBPF-24                1000000000               0.4539 ns/op
BenchmarkConnect/eBPF/mb_sock_connect        107              2475 ns/op
BenchmarkSockops/eBPF-24                1000000000               0.4545 ns/op
BenchmarkSockops/eBPF/mb_sockops             963               672.1 ns/op
PASS
ok      github.com/merbridge/merbridge  21.205s
```

The optimization results in a 20% performance improvement for connect programs.
