### PR TITLE
fix wrong volumes mount name for "host-var-run"

### DIFF
--- a/deploy/hot-restart-fd-server.yaml
+++ b/deploy/hot-restart-fd-server.yaml
@@ -51,8 +51,8 @@ spec:
       - operator: Exists
       volumes:
       - hostPath:
-          path: /proc
-        name: host-proc
+          path: /var/run
+        name: host-var-run
       - hostPath:
           path: /tmp
         name: tmp-dir


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

Fix mount volumes path , keep the same with others..
```
    volumes:
      - hostPath:
          path: /var/run
        name: host-var-run
      - hostPath:
          path: /tmp
        name: tmp-dir
```