### PR TITLE
Remove linters that are no longer supported

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,25 +34,21 @@ run:
 linters:
   disable-all: true
   enable:
-  - deadcode
   - errcheck
   - exportloopref
   - gocritic
   - gofumpt
   - goimports
-  - golint
   - gosimple
   - govet
   - ineffassign
   - lll
   - misspell
   - staticcheck
-  - structcheck
   - stylecheck
   - typecheck
   - unconvert
   - unparam
-  - varcheck
   fast: false
 
 linters-settings:
@@ -67,9 +63,6 @@ linters-settings:
   govet:
     # report about shadowed variables
     check-shadowing: false
-  golint:
-    # minimal confidence for issues, default is 0.8
-    min-confidence: 0.0
   goimports:
     # put imports beginning with prefix after 3rd-party packages;
     # it's a comma-separated list of prefixes


### PR DESCRIPTION
```bash
WARN [runner] The linter 'golint' is deprecated (since v1.41.0) due to: The repository of the linter has been archived by the owner.  Replaced by revive. 
WARN [runner] The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 
WARN [runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 
WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 

```