### PR TITLE
add support for osm and osm-edge.

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -236,3 +236,60 @@ jobs:
         [ "$(sudo cat /tmp/trace-log | grep 'bytes with eBPF successfully')" = "" ] && (echo eBPF redirect progs not work; sudo cat /tmp/trace-log; sudo bpftool prog; sudo bpftool map; cat mbctl.log; sudo ps -ef; exit 12)
         [ "$(sudo cat /tmp/trace-log | grep 'successfully deal DNS redirect query')" = "" ] && (echo DNS Proxy not work; sudo cat /tmp/trace-log; sudo bpftool prog; sudo bpftool map; cat mbctl.log; sudo ps -ef; exit 13)
         sudo rm -f /tmp/trace-log
+
+  # osm
+
+  osm-e2e:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 30
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'needs-e2e-test') }}
+    env:
+      OSM_VERSION: 'v1.2.3'
+      KIND_VERSION: v0.16.0
+      KERNEL_VERSION: v5.4
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+      - name: install bpftool
+        run: |
+          sudo bash ./scripts/build-bpftool.sh
+      - name: setup kind cluster
+        run: |
+          ./scripts/setup-kind.sh
+      - name: try load and unload
+        run: |
+          uname -a
+          make load
+          make attach
+          make clean
+      - name: install osm
+        run: |
+          bash ./scripts/install-osm.sh
+      - name: deploy test apps
+        run: |
+          kubectl create namespace e2e-test
+          osm namespace add e2e-test
+          kubectl apply -n e2e-test -f https://raw.githubusercontent.com/istio/istio/master/samples/sleep/sleep.yaml
+          kubectl apply -n e2e-test -f https://raw.githubusercontent.com/istio/istio/master/samples/helloworld/helloworld.yaml
+          while true; do [ "$(kubectl get po -l app=sleep -n e2e-test | grep '2/2')" = "" ] || break && (echo waiting for sleep app ready; sleep 3); done
+          while true; do [ "$(kubectl get po -l app=helloworld -n e2e-test | grep '2/2')" = "" ] || break && (echo waiting for helloworld app ready; sleep 3); done
+      - name: test connect without Merbridge
+        run: |
+          kubectl exec $(kubectl get po -l app=sleep -n e2e-test -o=jsonpath='{..metadata.name}') -c sleep -- curl -s -v helloworld:5000/hello
+      - name: install merbridge
+        run: |
+          nohup go run -exec sudo ./app/main.go -k -m osm -d > mbctl.log &
+          while true; do [ "$(cat mbctl.log | grep 'Pod Watcher Ready')" = "" ] || break && (echo waiting for mbctl watcher ready; sleep 3); done
+      - name: test connect with Merbridge
+        run: |
+          set -x
+          kubectl exec $(kubectl get po -l app=sleep -n e2e-test -o=jsonpath='{..metadata.name}') -c sleep -- curl -s -v helloworld:5000/hello
+          sudo cat /sys/kernel/debug/tracing/trace > /tmp/trace-log
+          # check if eBPF works
+          [ "$(sudo cat /tmp/trace-log | grep 'from user container')" = "" ] && (echo eBPF progs not work; sudo cat /tmp/trace-log; sudo bpftool prog; sudo bpftool map; cat mbctl.log; sudo ps -ef; exit 11)
+          [ "$(sudo cat /tmp/trace-log | grep 'bytes with eBPF successfully')" = "" ] && (echo eBPF redirect progs not work; sudo cat /tmp/trace-log; sudo bpftool prog; sudo bpftool map; cat mbctl.log; sudo ps -ef; exit 12)
+          [ "$(sudo cat /tmp/trace-log | grep 'successfully deal DNS redirect query')" = "" ] && (echo DNS Proxy not work; sudo cat /tmp/trace-log; sudo bpftool prog; sudo bpftool map; cat mbctl.log; sudo ps -ef; exit 13)
+          sudo rm -f /tmp/trace-log

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,10 @@ helm-istio:
 helm-kuma:
 	helm template --set-string "mode=kuma" -n "kuma-system" merbridge helm > deploy/all-in-one-kuma.yaml
 
+# generate merbridge on osm deploy templates
+helm-osm:
+	helm template --set-string "mode=osm" --set-string "use-reconnect=true" -n "osm-system" merbridge helm > deploy/all-in-one-osm.yaml
+
 # package helm release
 helm-package:
 	helm package helm

--- a/app/cmd/options/options.go
+++ b/app/cmd/options/options.go
@@ -30,9 +30,9 @@ func NewOptions() error {
 		log.SetLevel(log.DebugLevel)
 	}
 	switch config.Mode {
-	case config.ModeIstio, config.ModeLinkerd, config.ModeKuma:
+	case config.ModeIstio, config.ModeLinkerd, config.ModeKuma, config.ModeOsm:
 		return nil
 	default:
-		return fmt.Errorf("invalid mode %q, current only support istio, linkerd and kuma", config.Mode)
+		return fmt.Errorf("invalid mode %q, current only support istio, linkerd, kuma and osm", config.Mode)
 	}
 }

--- a/app/cmd/root.go
+++ b/app/cmd/root.go
@@ -89,7 +89,7 @@ func init() {
 	log.SetReportCaller(true)
 
 	// Get some flags from commands
-	rootCmd.PersistentFlags().StringVarP(&config.Mode, "mode", "m", config.ModeIstio, "Service mesh mode, current support istio, linkerd and kuma")
+	rootCmd.PersistentFlags().StringVarP(&config.Mode, "mode", "m", config.ModeIstio, "Service mesh mode, current support istio, linkerd, kuma and osm")
 	rootCmd.PersistentFlags().BoolVarP(&config.UseReconnect, "use-reconnect", "r", true, "Use re-connect mode for same-node acceleration")
 	rootCmd.PersistentFlags().BoolVarP(&config.Debug, "debug", "d", false, "Debug mode")
 	rootCmd.PersistentFlags().BoolVarP(&config.IsKind, "kind", "k", false, "Enable when Kubernetes is running in Kind")

--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -14,6 +14,8 @@ else ifeq ($(MESH_MODE),linkerd)
     MACROS:= $(MACROS) -DMESH=2
 else ifeq ($(MESH_MODE),kuma)
     MACROS:= $(MACROS) -DMESH=3
+else ifeq ($(MESH_MODE),osm)
+    MACROS:= $(MACROS) -DMESH=4
 else
 $(error MESH_MODE $(MESH_MODE) isn't supported)
 endif

--- a/bpf/headers/mesh.h
+++ b/bpf/headers/mesh.h
@@ -19,6 +19,7 @@ limitations under the License.
 #define ISTIO 1
 #define LINKERD 2
 #define KUMA 3
+#define OSM 4
 
 #ifndef MESH
 #define MESH 1
@@ -82,6 +83,29 @@ static const __u32 envoy_ip6[4] = {0, 0, 0, 6 << 24};
 
 #ifndef SIDECAR_USER_ID
 #define SIDECAR_USER_ID 5678
+#endif
+
+#ifndef DNS_CAPTURE_PORT
+#define DNS_CAPTURE_PORT 15053
+#endif
+
+// 127.0.0.6 (network order)
+static const __u32 envoy_ip = 127 + (6 << 24);
+// ::6 (network order)
+static const __u32 envoy_ip6[4] = {0, 0, 0, 6 << 24};
+
+#elif MESH == OSM
+
+#ifndef OUT_REDIRECT_PORT
+#define OUT_REDIRECT_PORT 15001
+#endif
+
+#ifndef IN_REDIRECT_PORT
+#define IN_REDIRECT_PORT 15003
+#endif
+
+#ifndef SIDECAR_USER_ID
+#define SIDECAR_USER_ID 1500
 #endif
 
 #ifndef DNS_CAPTURE_PORT

--- a/config/vars.go
+++ b/config/vars.go
@@ -24,6 +24,7 @@ const (
 	ModeIstio       = "istio"
 	ModeLinkerd     = "linkerd"
 	ModeKuma        = "kuma"
+	ModeOsm         = "osm"
 	LocalPodIps     = "/sys/fs/bpf/local_pod_ips"
 	PairOriginalDst = "/sys/fs/bpf/pair_original_dst"
 )

--- a/controller/pod.go
+++ b/controller/pod.go
@@ -117,6 +117,9 @@ func addFunc(obj interface{}) {
 	if config.Mode == config.ModeKuma && !pods.IsKumaInjectedSidecar(pod) {
 		return
 	}
+	if config.Mode == config.ModeOsm && !pods.IsOsmInjectedSidecar(pod) {
+		return
+	}
 	log.Debugf("got pod updated %s/%s", pod.Namespace, pod.Name)
 
 	_ip, _ := linux.IP2Linux(pod.Status.PodIP)
@@ -124,6 +127,8 @@ func addFunc(obj interface{}) {
 	p := podConfig{}
 	if config.Mode == config.ModeKuma {
 		parsePodConfigFromAnnotationsKuma(pod.Annotations, &p)
+	} else if config.Mode == config.ModeOsm {
+		parsePodConfigFromAnnotationsOsm(pod.Annotations, &p)
 	} else {
 		parsePodConfigFromAnnotations(pod.Annotations, &p)
 	}
@@ -278,6 +283,86 @@ func parsePodConfigFromAnnotationsKuma(annotations map[string]string, pod *podCo
 					break
 				}
 				pod.excludeOutPorts[i] = p
+			}
+		}
+	}
+}
+
+func parsePodConfigFromAnnotationsOsm(annotations map[string]string, pod *podConfig) {
+	statusPort := 15021
+	if v, ok := annotations["openservicemesh.io/port"]; ok {
+		vv, err := strconv.ParseUint(v, 10, 16)
+		if err == nil {
+			statusPort = int(vv)
+		}
+	}
+	pod.statusPort = uint16(statusPort)
+	excludeInboundPorts := []uint16{15000, 15001, 15003, 15010, 15021, 15050, 15128, 15901, 15902, 15903, 15904}
+	if v, ok := annotations["openservicemesh.io/inbound-port-exclusion-list"]; ok {
+		excludeInboundPorts = append(excludeInboundPorts, getPortsFromString(v)...)
+	}
+	if len(excludeInboundPorts) > 0 {
+		for i, p := range excludeInboundPorts {
+			if i >= MaxItemLen {
+				break
+			}
+			pod.excludeInPorts[i] = p
+		}
+	}
+	if v, ok := annotations["openservicemesh.io/outbound-port-exclusion-list"]; ok {
+		excludeOutboundPorts := getPortsFromString(v)
+		if len(excludeOutboundPorts) > 0 {
+			for i, p := range excludeOutboundPorts {
+				if i >= MaxItemLen {
+					break
+				}
+				pod.excludeOutPorts[i] = p
+			}
+		}
+	}
+
+	if v, ok := annotations["openservicemesh.io/inbound-port-inclusion-list"]; ok {
+		includeInboundPorts := getPortsFromString(v)
+		if len(includeInboundPorts) > 0 {
+			for i, p := range includeInboundPorts {
+				if i >= MaxItemLen {
+					break
+				}
+				pod.includeInPorts[i] = p
+			}
+		}
+	}
+	if v, ok := annotations["openservicemesh.io/outbound-port-inclusion-list"]; ok {
+		includeOutboundPorts := getPortsFromString(v)
+		if len(includeOutboundPorts) > 0 {
+			for i, p := range includeOutboundPorts {
+				if i >= MaxItemLen {
+					break
+				}
+				pod.includeOutPorts[i] = p
+			}
+		}
+	}
+
+	if v, ok := annotations["openservicemesh.io/outbound-ip-range-exclusion-list"]; ok {
+		excludeOutboundIPRanges := getIPRangesFromString(v)
+		if len(excludeOutboundIPRanges) > 0 {
+			for i, p := range excludeOutboundIPRanges {
+				if i >= MaxItemLen {
+					break
+				}
+				pod.excludeOutRanges[i] = p
+			}
+		}
+	}
+	if v, ok := annotations["openservicemesh.io/outbound-ip-range-inclusion-list"]; ok {
+		includeOutboundIPRanges := getIPRangesFromString(v)
+		if len(includeOutboundIPRanges) > 0 {
+			for i, p := range includeOutboundIPRanges {
+				if i >= MaxItemLen {
+					break
+				}
+				pod.includeOutRanges[i] = p
 			}
 		}
 	}

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -52,6 +52,15 @@ helm install -n linkerd --set mode=linkerd merbridge helm
 helm install -n kuma-system --set mode=kuma merbridge helm
 ```
 
+### Install Merbridge on Osm/Osm-edge
+
++ set mode=osm to switch to osm/osm-edge mode
++ set namespace where merbridge is going to install by -n .
+
+``` bash
+helm install -n osm-system --set mode=osm merbridge helm
+```
+
 ### Uninstall
 
 + execute this command in the namespace where merbridge has been installed
@@ -76,6 +85,8 @@ make helm-istio
 make helm-linkerd
 # update kuma deploy yaml
 make helm-kuma
+# update osm deploy yaml
+make helm-osm
 # package helm charts
 make helm-package
 ```

--- a/deploy/all-in-one-osm.yaml
+++ b/deploy/all-in-one-osm.yaml
@@ -1,0 +1,127 @@
+---
+# Source: merbridge/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: merbridge
+  namespace: osm-system
+  labels:
+    app: merbridge
+---
+# Source: merbridge/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: merbridge
+  labels:
+    app: merbridge
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - get
+  - watch
+---
+# Source: merbridge/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: merbridge
+  labels:
+    app: merbridge
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: merbridge
+subjects:
+- kind: ServiceAccount
+  name: merbridge
+  namespace: osm-system
+---
+# Source: merbridge/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: merbridge
+  namespace: osm-system
+  labels:
+    app: merbridge
+spec:
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: merbridge
+  template:
+    metadata:
+      labels:
+        app: merbridge
+    spec:
+      hostNetwork: true
+      containers:
+      - image: "ghcr.io/merbridge/merbridge:latest"
+        imagePullPolicy: Always
+        name: merbridge
+        args:
+        - /app/mbctl
+        - -m
+        - osm
+        - --use-reconnect=true
+        - --cni-mode=false
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - make
+              - -k
+              - clean
+        resources:
+          requests:
+            cpu: 100m
+            memory: 200Mi
+          limits:
+            cpu: 300m
+            memory: 200Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+          - mountPath: /sys/fs/cgroup
+            name: sys-fs-cgroup
+          - mountPath: /host/opt/cni/bin
+            name: cni-bin-dir
+          - mountPath: /host/etc/cni/net.d
+            name: cni-config-dir
+          - mountPath: /host/proc
+            name: host-proc
+          - mountPath: /host/var/run
+            name: host-var-run
+            mountPropagation: Bidirectional
+      dnsPolicy: ClusterFirst
+      nodeSelector:
+        kubernetes.io/os: linux
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      serviceAccount: merbridge
+      serviceAccountName: merbridge
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - operator: Exists
+      volumes:
+      - hostPath:
+          path: /sys/fs/cgroup
+        name: sys-fs-cgroup
+      - hostPath:
+          path: /proc
+        name: host-proc
+      - hostPath:
+          path: /opt/cni/bin
+        name: cni-bin-dir
+      - hostPath:
+          path: /etc/cni/net.d
+        name: cni-config-dir
+      - hostPath:
+          path: /var/run
+        name: host-var-run

--- a/hack/reload-prog.sh
+++ b/hack/reload-prog.sh
@@ -20,7 +20,7 @@ usage() {
 			OPTIONS := {-v}
 				-v : Enable verbose mode. It prints more information for debugging the failure of loading
 
-			MODE := {istio | kuma}
+			MODE := {istio | kuma | osm}
 			NODE := {all | <node where ebpf programs needs reload>}
 			EBPFPROG := {all | bind | connect | sockops | getsock | redir | sendmsg | recvmsg | xdp}
 
@@ -44,7 +44,10 @@ usage() {
 
 			Load bind eBPF program on all worker nodes for kuma service mesh
 			./reload-prog.sh -m kuma -n all -p bind
-	
+
+      Load bind eBPF program on all worker nodes for osm/osm-edge service mesh
+      ./reload-prog.sh -m osm -n all -p bind
+
 			Enable verbose mode of the script
 			./reload-prog.sh -v -n worker-3 -p xdp		"
 	exit 1
@@ -90,6 +93,7 @@ fi
 case $mode in
   istio ) mesh_number=1; namespace="istio-system";;
   kuma )  mesh_number=3; namespace="kuma-system";;
+  osm )  mesh_number=3; namespace="osm-system";;
 esac
 
 if ! command -v kubectl &> /dev/null && command -v clang &> /dev/null && command -v bpftool &> /dev/null

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -64,7 +64,7 @@ Merbridge args command
 - /app/mbctl
 - -m
 - {{ .Values.mode }}
-- --use-reconnect={{ if or (eq .Values.mode "istio") (eq .Values.mode "kuma") }}true{{ else }}false{{ end }}
+- --use-reconnect={{ if or (eq .Values.mode "istio") (eq .Values.mode "kuma") (eq .Values.mode "osm") }}true{{ else }}false{{ end }}
 - --cni-mode={{ .Values.cniMode }}
 {{- if ne .Values.mountPath.proc "/host/proc" }}
 - --host-proc={{ .Values.mountPath.proc }}

--- a/internal/pods/util.go
+++ b/internal/pods/util.go
@@ -44,3 +44,10 @@ func IsKumaInjectedSidecar(pod *v1.Pod) bool {
 	}
 	return false
 }
+
+func IsOsmInjectedSidecar(pod *v1.Pod) bool {
+	if _, found := pod.Labels["osm-proxy-uuid"]; found {
+		return true
+	}
+	return false
+}

--- a/scripts/install-osm.sh
+++ b/scripts/install-osm.sh
@@ -1,0 +1,44 @@
+# Copyright © 2022 Merbridge Authors
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#!/usr/bin/env bash
+
+set -ex
+
+OSM_VERSION=${OSM_VERSION:-v1.2.3}
+if [ -z "$SKIP_INSTALL" ]; then
+    tmp=$(mktemp -d)
+    pushd ${tmp}
+    wget -c https://github.com/openservicemesh/osm/releases/download/${OSM_VERSION}/osm-${OSM_VERSION}-linux-amd64.tar.gz
+    tar -zxf osm-${OSM_VERSION}-linux-amd64.tar.gz
+    sudo cp -rf linux-amd64/osm /usr/local/bin
+    popd
+    rm -rf "${tmp}"
+fi
+
+osm_namespace=osm-system
+osm_mesh_name=osm
+
+osm install \
+    --mesh-name "$osm_mesh_name" \
+    --osm-namespace "$osm_namespace" \
+    --set=osm.certificateProvider.kind=tresor \
+    --set=osm.image.pullPolicy=Always \
+    --set=osm.enablePermissiveTrafficPolicy=true \
+    --verbose
+
+kubectl wait --for=condition=ready pod -n $osm_namespace -l app=osm-bootstrap --timeout=180s
+
+kubectl wait --for=condition=ready pod -n $osm_namespace -l app=osm-injector --timeout=180s
+
+kubectl wait --for=condition=ready pod -n $osm_namespace -l app=osm-controller --timeout=180s


### PR DESCRIPTION
[Open Service Mesh (OSM)](https://github.com/openservicemesh/osm) is a lightweight, extensible, cloud native [service mesh](https://en.wikipedia.org/wiki/Service_mesh) that allows users to uniformly manage, secure, and get out-of-the-box observability features for highly dynamic microservice environments.

[Open Service Mesh Edge (OSM-Edge)](https://github.com/flomesh-io/osm-edge) fork from [Open Service Mesh](https://github.com/openservicemesh/osm), built purposely for Edge computing. [OSM edge](https://github.com/flomesh-io/osm-edge) uses lightweight, Cloud Native, programmable proxy [Pipy](https://flomesh.io/) as sidecar proxy.

PR is bundled with Unit Test (UT) and E2E test suite to cover the changes.