### PR TITLE
sidecar detection mode

### DIFF
--- a/app/cmd/root.go
+++ b/app/cmd/root.go
@@ -38,7 +38,7 @@ var rootCmd = &cobra.Command{
 	Short: "Use eBPF to speed up your Service Mesh like crossing an Einstein-Rosen Bridge.",
 	Long:  `Use eBPF to speed up your Service Mesh like crossing an Einstein-Rosen Bridge.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := ebpfs.LoadMBProgs(config.Mode, config.UseReconnect, config.Debug); err != nil {
+		if err := ebpfs.LoadMBProgs(config.Mode, config.UseReconnect, config.EnableCNI, config.Debug); err != nil {
 			return fmt.Errorf("failed to load ebpf programs: %v", err)
 		}
 

--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -20,6 +20,14 @@ else
 $(error MESH_MODE $(MESH_MODE) isn't supported)
 endif
 
+CNI_MODE ?= false
+
+ifeq ($(CNI_MODE),true)
+	MACROS:= $(MACROS) -DENABLE_CNI_MODE=1
+else
+	MACROS:= $(MACROS) -DENABLE_CNI_MODE=0
+endif
+
 ENABLE_IPV4 ?= true
 ENABLE_IPV6 ?= false
 

--- a/bpf/headers/cgroup.h
+++ b/bpf/headers/cgroup.h
@@ -20,6 +20,10 @@ limitations under the License.
 #include "mesh.h"
 #include <linux/bpf.h>
 
+#ifndef ENABLE_CNI_MODE
+#define ENABLE_CNI_MODE 0
+#endif
+
 #define DNS_CAPTURE_PORT_FLAG (1 << 1)
 
 // get_current_cgroup_info return 1 if succeed, 0 for error
@@ -40,6 +44,7 @@ static inline int get_current_cgroup_info(void *ctx,
             .flags = 0,
             .detected_flags = 0,
         };
+#if ENABLE_CNI_MODE
         // get ip addresses of current pod/ns.
         struct bpf_sock_tuple tuple = {};
         tuple.ipv4.dport = bpf_htons(SOCK_IP_MARK_PORT);
@@ -62,6 +67,33 @@ static inline int get_current_cgroup_info(void *ctx,
             // not in mesh
             _default.is_in_mesh = 0;
         }
+#else
+        // not checked ever
+        if (!is_port_listen_current_ns(ctx, ip_zero, OUT_REDIRECT_PORT)) {
+            // not in mesh
+            _default.is_in_mesh = 0;
+            debugf("can not get port listen for cgroup(%ld)", cgroup_id);
+        } else {
+            _default.is_in_mesh = 1;
+            // get ip addresses of current pod/ns.
+            struct bpf_sock_tuple tuple = {};
+            tuple.ipv4.dport = bpf_htons(SOCK_IP_MARK_PORT);
+            tuple.ipv4.daddr = 0;
+            struct bpf_sock *s = bpf_sk_lookup_tcp(
+                ctx, &tuple, sizeof(tuple.ipv4), BPF_F_CURRENT_NETNS, 0);
+            if (s) {
+                __u32 curr_ip_mark = s->mark;
+                bpf_sk_release(s);
+                __u32 *ip = (__u32 *)bpf_map_lookup_elem(&mark_pod_ips_map,
+                                                         &curr_ip_mark);
+                if (!ip) {
+                    debugf("get ip for mark 0x%x error", curr_ip_mark);
+                } else {
+                    set_ipv6(_default.cgroup_ip, ip); // network order
+                }
+            }
+        }
+#endif
         if (bpf_map_update_elem(&cgroup_info_map, &cgroup_id, &_default,
                                 BPF_ANY)) {
             printk("update cgroup_info_map of cgroup(%ld) error", cgroup_id);

--- a/bpf/headers/cgroup.h
+++ b/bpf/headers/cgroup.h
@@ -40,30 +40,27 @@ static inline int get_current_cgroup_info(void *ctx,
             .flags = 0,
             .detected_flags = 0,
         };
-        // not checked ever
-        if (!is_port_listen_current_ns(ctx, ip_zero, OUT_REDIRECT_PORT)) {
+        // get ip addresses of current pod/ns.
+        struct bpf_sock_tuple tuple = {};
+        tuple.ipv4.dport = bpf_htons(SOCK_IP_MARK_PORT);
+        tuple.ipv4.daddr = 0;
+        struct bpf_sock *s = bpf_sk_lookup_tcp(
+            ctx, &tuple, sizeof(tuple.ipv4), BPF_F_CURRENT_NETNS, 0);
+        if (s) {
+            __u32 curr_ip_mark = s->mark;
+            bpf_sk_release(s);
+            __u32 *ip = (__u32 *)bpf_map_lookup_elem(&mark_pod_ips_map,
+                                                     &curr_ip_mark);
+            if (!ip) {
+                debugf("get ip for mark 0x%x error", curr_ip_mark);
+            } else {
+                set_ipv6(_default.cgroup_ip, ip); // network order
+            }
+            // in mesh
+            _default.is_in_mesh = 1;
+        } else {
             // not in mesh
             _default.is_in_mesh = 0;
-            debugf("can not get port listen for cgroup(%ld)", cgroup_id);
-        } else {
-            _default.is_in_mesh = 1;
-            // get ip addresses of current pod/ns.
-            struct bpf_sock_tuple tuple = {};
-            tuple.ipv4.dport = bpf_htons(SOCK_IP_MARK_PORT);
-            tuple.ipv4.daddr = 0;
-            struct bpf_sock *s = bpf_sk_lookup_tcp(
-                ctx, &tuple, sizeof(tuple.ipv4), BPF_F_CURRENT_NETNS, 0);
-            if (s) {
-                __u32 curr_ip_mark = s->mark;
-                bpf_sk_release(s);
-                __u32 *ip = (__u32 *)bpf_map_lookup_elem(&mark_pod_ips_map,
-                                                         &curr_ip_mark);
-                if (!ip) {
-                    debugf("get ip for mark 0x%x error", curr_ip_mark);
-                } else {
-                    set_ipv6(_default.cgroup_ip, ip); // network order
-                }
-            }
         }
         if (bpf_map_update_elem(&cgroup_info_map, &cgroup_id, &_default,
                                 BPF_ANY)) {

--- a/bpf/headers/cgroup.h
+++ b/bpf/headers/cgroup.h
@@ -44,13 +44,13 @@ static inline int get_current_cgroup_info(void *ctx,
         struct bpf_sock_tuple tuple = {};
         tuple.ipv4.dport = bpf_htons(SOCK_IP_MARK_PORT);
         tuple.ipv4.daddr = 0;
-        struct bpf_sock *s = bpf_sk_lookup_tcp(
-            ctx, &tuple, sizeof(tuple.ipv4), BPF_F_CURRENT_NETNS, 0);
+        struct bpf_sock *s = bpf_sk_lookup_tcp(ctx, &tuple, sizeof(tuple.ipv4),
+                                               BPF_F_CURRENT_NETNS, 0);
         if (s) {
             __u32 curr_ip_mark = s->mark;
             bpf_sk_release(s);
-            __u32 *ip = (__u32 *)bpf_map_lookup_elem(&mark_pod_ips_map,
-                                                     &curr_ip_mark);
+            __u32 *ip =
+                (__u32 *)bpf_map_lookup_elem(&mark_pod_ips_map, &curr_ip_mark);
             if (!ip) {
                 debugf("get ip for mark 0x%x error", curr_ip_mark);
             } else {

--- a/internal/ebpfs/prog.go
+++ b/internal/ebpfs/prog.go
@@ -25,7 +25,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func LoadMBProgs(meshMode string, useReconnect bool, debug bool) error {
+func LoadMBProgs(meshMode string, useReconnect, useCniMode, debug bool) error {
 	if os.Getuid() != 0 {
 		return fmt.Errorf("root user in required for this process or container")
 	}
@@ -37,6 +37,9 @@ func LoadMBProgs(meshMode string, useReconnect bool, debug bool) error {
 	}
 	if useReconnect {
 		cmd.Env = append(cmd.Env, "USE_RECONNECT=1")
+	}
+	if useCniMode {
+		cmd.Env = append(cmd.Env, "ENABLE_CNI_MODE=1")
 	}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
问题:
业务容器和边车容器启动的先后顺序是不定的;
如果业务容器先启动,但边车容器还未启动,这时探测边车容器的监听端口,探测不到,所以会标识_default.is_in_mesh = 0;
同时探测的结果会被 cache,不会再被重复探测,即is_in_mesh永远是 0,导致mb_connect.c中的几处分支逻辑永远不会执行.

解决方法:
因为 cni plugin 中已经校验当前的 POD 是否被 mess 纳管,进而决定是否启动SOCK_IP_MARK_PORT的监听;
即 POD 中SOCK_IP_MARK_PORT总是最先启动的, 所以只需探测SOCK_IP_MARK_PORT即可.