### PR TITLE
fix build-push-action produces unknown arch

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -92,6 +92,7 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
+          provenance: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -78,6 +78,7 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
+          provenance: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
![image](https://user-images.githubusercontent.com/10629406/231206101-9241d288-285f-4662-a887-338077ed87f7.png)

The multi-architecture image produced by build-push-action will contain an image of the unknown architecture.
The solution is: https://github.com/docker/build-push-action/issues/820#issuecomment-1484092146

**Which issue(s) this PR fixes**:
https://github.com/docker/build-push-action/issues/820
